### PR TITLE
save/restore states

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ if (keystorePropertiesFile.exists() && keystorePropertiesFile.canRead()) {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion '28.0.3'
+    buildToolsVersion '29.0.2'
     defaultConfig {
         applicationId "io.github.gmathi.novellibrary"
         minSdkVersion 21
@@ -47,6 +47,11 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 
@@ -139,7 +144,7 @@ dependencies {
 
     kapt 'com.github.bumptech.glide:compiler:4.8.0'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/ChaptersPagerActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/ChaptersPagerActivity.kt
@@ -1,11 +1,10 @@
 package io.github.gmathi.novellibrary.activity
 
-import android.content.Intent
 import android.os.Bundle
-import androidx.core.content.ContextCompat
-import androidx.appcompat.view.ActionMode
 import android.view.Menu
 import android.view.MenuItem
+import androidx.appcompat.view.ActionMode
+import androidx.core.content.ContextCompat
 import co.metalab.asyncawait.async
 import com.afollestad.materialdialogs.MaterialDialog
 import com.google.gson.Gson
@@ -29,7 +28,6 @@ import org.greenrobot.eventbus.EventBus
 import java.io.File
 import java.util.*
 import kotlin.collections.ArrayList
-
 
 
 class ChaptersPagerActivity : BaseActivity(), ActionMode.Callback {
@@ -56,7 +54,7 @@ class ChaptersPagerActivity : BaseActivity(), ActionMode.Callback {
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        novel = intent.getSerializableExtra("novel") as Novel
+        novel = intent.getParcelableExtra("novel")!!
         showSources = novel.metaData[Constants.MetaDataKeys.SHOW_SOURCES]?.toBoolean() ?: false
         dbHelper.updateNewReleasesCount(novel.id, 0L)
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/MetaDataActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/MetaDataActivity.kt
@@ -29,7 +29,7 @@ class MetaDataActivity : BaseActivity(), GenericAdapter.Listener<Map.Entry<Strin
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        novel = intent.getSerializableExtra("novel") as Novel
+        novel = intent.getParcelableExtra("novel")!!
         setRecyclerView()
 
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/NavDrawerActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/NavDrawerActivity.kt
@@ -286,7 +286,7 @@ class NavDrawerActivity : BaseActivity(), NavigationView.OnNavigationItemSelecte
 
     private fun checkIntentForNotificationData() {
         if (intent.extras != null && intent.extras!!.containsKey("novel")) {
-            val novel = intent.extras!!.getSerializable("novel") as? Novel
+            val novel = intent.extras!!.getParcelable<Novel>("novel")
             novel?.let {
                 intent.extras!!.remove("novel")
                 startChaptersActivity(novel)

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/NovelDetailsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/NovelDetailsActivity.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import androidx.core.content.ContextCompat
 import android.text.Html
 import android.text.Spannable
 import android.text.SpannableString
@@ -19,6 +18,7 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import co.metalab.asyncawait.async
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.Theme
@@ -49,7 +49,7 @@ class NovelDetailsActivity : BaseActivity(), TextViewLinkHandler.OnClickListener
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_novel_details)
 
-        novel = intent.getSerializableExtra("novel") as Novel
+        novel = intent.getParcelableExtra("novel")!!
         getNovelInfoDB()
         if (intent.hasExtra(Constants.JUMP))
             startChaptersActivity(novel, true)

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/ReaderDBPagerActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/ReaderDBPagerActivity.kt
@@ -86,7 +86,7 @@ class ReaderDBPagerActivity :
         setContentView(R.layout.activity_reader_pager)
         sourceId = intent.getLongExtra("sourceId", -1L)
 
-        val tempNovel = intent.getSerializableExtra("novel") as Novel?
+        val tempNovel = intent.getParcelableExtra<Novel?>("novel")
         if (tempNovel == null || tempNovel.chaptersCount.toInt() == 0) {
             finish()
             return

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/SearchUrlActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/SearchUrlActivity.kt
@@ -1,14 +1,17 @@
 package io.github.gmathi.novellibrary.activity
 
 import android.os.Bundle
+import android.view.MenuItem
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
-import android.view.MenuItem
 import io.github.gmathi.novellibrary.R
 import io.github.gmathi.novellibrary.fragment.SearchUrlFragment
 import kotlinx.android.synthetic.main.activity_search_results.*
 
 class SearchUrlActivity : BaseActivity() {
+
+    private var fragment: Fragment? = null
+    private lateinit var url: String
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -16,23 +19,35 @@ class SearchUrlActivity : BaseActivity() {
         setSupportActionBar(toolbar)
         supportActionBar?.title = "Search: ${intent.getStringExtra("title")}"
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        val url = intent.getStringExtra("url")
-        val fragment = SearchUrlFragment.newInstance(url)
+        url =
+                if (savedInstanceState != null && savedInstanceState.containsKey("url"))
+                    savedInstanceState.getString("url")!!
+                else
+                    intent.getStringExtra("url")!!
+
+        val fragment =
+                when {
+                    fragment != null -> fragment!!
+                    savedInstanceState == null -> SearchUrlFragment.newInstance(url)
+                    else -> restoreFragment(savedInstanceState, "SearchUrlFragment") ?: SearchUrlFragment.newInstance(url)
+                }
         replaceFragment(fragment, "SearchUrlFragment")
     }
 
     private fun replaceFragment(fragment: Fragment, tag: String) {
-        val existingFrag = supportFragmentManager.findFragmentByTag(tag)
-        var replaceFrag = fragment
-        if (existingFrag != null) {
-            replaceFrag = existingFrag
-        }
-
+        this.fragment = fragment
         supportFragmentManager.beginTransaction()
-            .replace(R.id.fragmentContainer, replaceFrag, tag)
+            .replace(R.id.fragmentContainer, fragment, tag)
             .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
             .addToBackStack(tag)
             .commitAllowingStateLoss()
+    }
+
+    private fun restoreFragment(savedInstanceState: Bundle, tag: String): Fragment? {
+        val fragment =  supportFragmentManager.getFragment(savedInstanceState, tag)
+        if (fragment != null)
+            this.fragment = fragment
+        return fragment
     }
 
     override fun onBackPressed() {
@@ -42,6 +57,13 @@ class SearchUrlActivity : BaseActivity() {
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {
         if (item?.itemId == android.R.id.home) finish()
         return super.onOptionsItemSelected(item)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString("url", url)
+        if (fragment != null)
+            supportFragmentManager.putFragment(outState, "SearchUrlFragment", fragment!!)
     }
 
 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/adapter/GenericFragmentStatePagerAdapter.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/adapter/GenericFragmentStatePagerAdapter.kt
@@ -6,7 +6,7 @@ import androidx.fragment.app.FragmentStatePagerAdapter
 import java.util.*
 
 
-class GenericFragmentStatePagerAdapter(manager: FragmentManager, private val titles: Array<String>?, private val pagerCount: Int, val listener: Listener) : FragmentStatePagerAdapter(manager) {
+class GenericFragmentStatePagerAdapter(manager: FragmentManager, private val titles: Array<String>?, private val pagerCount: Int, val listener: Listener) : FragmentStatePagerAdapter(manager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
 
     override fun getItem(position: Int): Fragment = listener.getFragmentForItem(position)
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/extensions/Activity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/extensions/Activity.kt
@@ -3,11 +3,10 @@ package io.github.gmathi.novellibrary.extensions
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import com.google.android.material.snackbar.Snackbar
-import androidx.appcompat.app.AppCompatActivity
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import com.tapadoo.alerter.Alerter
 import io.github.gmathi.novellibrary.R
 import io.github.gmathi.novellibrary.activity.*
@@ -48,7 +47,7 @@ fun AppCompatActivity.snackBar(view: View, message: String) {
 fun AppCompatActivity.startChaptersActivity(novel: Novel, jumpToReader: Boolean = false) {
     val intent = Intent(this, ChaptersPagerActivity::class.java)
     val bundle = Bundle()
-    bundle.putSerializable("novel", novel)
+    bundle.putParcelable("novel", novel)
     if (jumpToReader)
         bundle.putBoolean(Constants.JUMP, true)
     intent.putExtras(bundle)
@@ -58,7 +57,7 @@ fun AppCompatActivity.startChaptersActivity(novel: Novel, jumpToReader: Boolean 
 //fun Activity.startOldChaptersActivity(novel: Novel, jumpToReader: Boolean = false) {
 //    val intent = Intent(this, OldChaptersActivity::class.java)
 //    val bundle = Bundle()
-//    bundle.putSerializable("novel", novel)
+//    bundle.putParcelable("novel", novel)
 //    if (jumpToReader)
 //        bundle.putBoolean(Constants.JUMP, true)
 //    intent.putExtras(bundle)
@@ -68,7 +67,7 @@ fun AppCompatActivity.startChaptersActivity(novel: Novel, jumpToReader: Boolean 
 fun AppCompatActivity.startMetadataActivity(novel: Novel) {
     val intent = Intent(this, MetaDataActivity::class.java)
     val bundle = Bundle()
-    bundle.putSerializable("novel", novel)
+    bundle.putParcelable("novel", novel)
     intent.putExtras(bundle)
     startActivityForResult(intent, Constants.METADATA_ACT_REQ_CODE)
 }
@@ -76,7 +75,7 @@ fun AppCompatActivity.startMetadataActivity(novel: Novel) {
 fun AppCompatActivity.startWebViewActivity(url: String) {
     val intent = Intent(this, WebViewActivity::class.java)
     val bundle = Bundle()
-    bundle.putSerializable("url", url)
+    bundle.putString("url", url)
     intent.putExtras(bundle)
     startActivity(intent)
 }
@@ -84,7 +83,7 @@ fun AppCompatActivity.startWebViewActivity(url: String) {
 fun AppCompatActivity.startReaderDBPagerActivity(novel: Novel) {
     val intent = Intent(this, ReaderDBPagerActivity::class.java)
     val bundle = Bundle()
-    bundle.putSerializable("novel", novel)
+    bundle.putParcelable("novel", novel)
     intent.putExtras(bundle)
     startActivityForResult(intent, Constants.READER_ACT_REQ_CODE)
 }
@@ -166,7 +165,7 @@ fun AppCompatActivity.startNovelDownloadsActivity() {
 fun AppCompatActivity.startNovelDetailsActivity(novel: Novel, jumpToReader: Boolean = false) {
     val intent = Intent(this, NovelDetailsActivity::class.java)
     val bundle = Bundle()
-    bundle.putSerializable("novel", novel)
+    bundle.putParcelable("novel", novel)
     if (jumpToReader)
         bundle.putBoolean(Constants.JUMP, true)
     intent.putExtras(bundle)

--- a/app/src/main/java/io/github/gmathi/novellibrary/extensions/Fragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/extensions/Fragment.kt
@@ -2,9 +2,9 @@ package io.github.gmathi.novellibrary.extensions
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.fragment.app.Fragment
-import androidx.appcompat.app.AppCompatActivity
 import android.view.inputmethod.InputMethodManager
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
 import io.github.gmathi.novellibrary.activity.ReaderDBPagerActivity
 import io.github.gmathi.novellibrary.activity.WebViewActivity
 import io.github.gmathi.novellibrary.model.Novel
@@ -23,7 +23,7 @@ fun Fragment.isFragmentActive(): Boolean {
 fun Fragment.startReaderDBPagerActivity(novel: Novel, sourceId: Long) {
     val intent = Intent(context, ReaderDBPagerActivity::class.java)
     val bundle = Bundle()
-    bundle.putSerializable("novel", novel)
+    bundle.putParcelable("novel", novel)
     bundle.putLong("sourceId", sourceId)
     intent.putExtras(bundle)
     startActivityForResult(intent, Constants.READER_ACT_REQ_CODE)
@@ -32,7 +32,7 @@ fun Fragment.startReaderDBPagerActivity(novel: Novel, sourceId: Long) {
 fun Fragment.startWebViewActivity(url: String) {
     val intent = Intent(context, WebViewActivity::class.java)
     val bundle = Bundle()
-    bundle.putSerializable("url", url)
+    bundle.putString("url", url)
     intent.putExtras(bundle)
     startActivity(intent)
 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/ChaptersFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/ChaptersFragment.kt
@@ -3,9 +3,9 @@ package io.github.gmathi.novellibrary.fragment
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.Parcelable
+import android.view.*
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DividerItemDecoration
-import android.view.*
 import co.metalab.asyncawait.async
 import com.afollestad.materialdialogs.MaterialDialog
 import com.hanks.library.AnimateCheckBox
@@ -36,7 +36,7 @@ class ChaptersFragment : BaseFragment(),
 
         fun newInstance(novel: Novel, sourceId: Long): ChaptersFragment {
             val bundle = Bundle()
-            bundle.putSerializable(NOVEL, novel)
+            bundle.putParcelable(NOVEL, novel)
             bundle.putLong(SOURCE_ID, sourceId)
             val fragment = ChaptersFragment()
             fragment.arguments = bundle
@@ -63,7 +63,7 @@ class ChaptersFragment : BaseFragment(),
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        novel = arguments!!.getSerializable(NOVEL) as Novel
+        novel = arguments!!.getParcelable(NOVEL)!!
         sourceId = arguments!!.getLong(SOURCE_ID)
 
         progressLayout.showLoading()

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/LibraryFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/LibraryFragment.kt
@@ -4,18 +4,18 @@ import android.content.Intent
 import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.os.Handler
-import androidx.core.content.ContextCompat
+import android.view.*
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.PopupMenu
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.ItemTouchHelper
-import android.view.*
 import co.metalab.asyncawait.async
 import com.afollestad.materialdialogs.MaterialDialog
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import com.tapadoo.alerter.Alerter
 import io.github.gmathi.novellibrary.R
-import io.github.gmathi.novellibrary.activity.*
+import io.github.gmathi.novellibrary.activity.NovelDetailsActivity
 import io.github.gmathi.novellibrary.adapter.GenericAdapter
 import io.github.gmathi.novellibrary.database.*
 import io.github.gmathi.novellibrary.dbHelper
@@ -350,7 +350,7 @@ class LibraryFragment : BaseFragment(), GenericAdapter.Listener<Novel>, SimpleIt
     private fun startNovelDetailsActivity(novel: Novel, jumpToReader: Boolean) {
         val intent = Intent(activity, NovelDetailsActivity::class.java)
         val bundle = Bundle()
-        bundle.putSerializable("novel", novel)
+        bundle.putParcelable("novel", novel)
         if (jumpToReader)
             bundle.putBoolean(Constants.JUMP, true)
         intent.putExtras(bundle)

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/LibraryPagerFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/LibraryPagerFragment.kt
@@ -24,6 +24,15 @@ class LibraryPagerFragment : BaseFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        novelSections.clear()
+
+        if (savedInstanceState != null) {
+            if (savedInstanceState.containsKey("novelSections")) {
+                novelSections.clear()
+                novelSections.addAll(savedInstanceState.getParcelableArrayList("novelSections")!!)
+            }
+        }
+
         setHasOptionsMenu(true)
     }
 
@@ -35,22 +44,21 @@ class LibraryPagerFragment : BaseFragment() {
         toolbar.title = getString(R.string.title_library)
         (activity as NavDrawerActivity).setToolbar(toolbar)
 
+        if (novelSections.isEmpty())
+            getNovelSections()
+
         setViewPager()
 
         novelSectionSettings.setOnClickListener {
             startActivityForResult(Intent(activity, NovelSectionsActivity::class.java), Constants.NOVEL_SECTIONS_ACT_REQ_CODE)
         }
 
+        android.util.Log.i("MyState4", "onActivityCreated with ${if (savedInstanceState == null) "null" else "non null"} state")
     }
 
     private fun setViewPager() {
         while (childFragmentManager.backStackEntryCount > 0)
             childFragmentManager.popBackStack()
-
-        //We Manually add this because we want it to be static and the name to be change in different languages
-        novelSections.clear()
-        novelSections.add(NovelSection(-1L, getString(R.string.default_novel_section_name)))
-        novelSections.addAll(dbHelper.getAllNovelSections())
 
         val titles = Array(novelSections.size, init = {
             novelSections[it].name!!
@@ -62,12 +70,25 @@ class LibraryPagerFragment : BaseFragment() {
         tabStrip.setViewPager(viewPager)
     }
 
+    private fun getNovelSections() {
+        novelSections.clear()
+        //We Manually add this because we want it to be static and the name to be change in different languages
+        novelSections.add(NovelSection(-1L, getString(R.string.default_novel_section_name)))
+        novelSections.addAll(dbHelper.getAllNovelSections())
+    }
+
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (requestCode == Constants.NOVEL_SECTIONS_ACT_REQ_CODE) {
+            getNovelSections()
             setViewPager()
         } else {
             super.onActivityResult(requestCode, resultCode, data)
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putParcelableArrayList("novelSections", novelSections)
     }
 
 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchFragment.kt
@@ -28,6 +28,14 @@ class SearchFragment : BaseFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (savedInstanceState != null) {
+            if (savedInstanceState.containsKey("searchTerm"))
+                searchTerm = savedInstanceState.getString("searchTerm")
+            if (savedInstanceState.containsKey("searchMode"))
+                searchMode = savedInstanceState.getBoolean("searchMode")
+        }
+
         setHasOptionsMenu(true)
     }
 
@@ -38,13 +46,6 @@ class SearchFragment : BaseFragment() {
         super.onActivityCreated(savedInstanceState)
 
         setSearchView()
-
-        if (savedInstanceState != null) {
-            if (savedInstanceState.containsKey("searchTerm"))
-                searchTerm = savedInstanceState.getString("searchTerm")
-            if (savedInstanceState.containsKey("searchMode"))
-                searchMode = savedInstanceState.getBoolean("searchMode")
-        }
 
         if (searchMode && searchTerm != null)
             searchNovels(searchTerm!!)

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchFragment.kt
@@ -2,15 +2,17 @@ package io.github.gmathi.novellibrary.fragment
 
 import android.animation.Animator
 import android.os.Bundle
-import androidx.core.view.GravityCompat
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
+import androidx.core.view.GravityCompat
 import io.github.gmathi.novellibrary.R
-import io.github.gmathi.novellibrary.adapter.*
+import io.github.gmathi.novellibrary.adapter.GenericFragmentStatePagerAdapter
+import io.github.gmathi.novellibrary.adapter.NavPageListener
+import io.github.gmathi.novellibrary.adapter.SearchResultsListener
 import io.github.gmathi.novellibrary.dataCenter
 import io.github.gmathi.novellibrary.extensions.hideSoftKeyboard
-import io.github.gmathi.novellibrary.model.Novel
 import io.github.gmathi.novellibrary.util.SimpleAnimationListener
 import io.github.gmathi.novellibrary.util.SuggestionsBuilder
 import io.github.gmathi.novellibrary.util.addToSearchHistory
@@ -21,8 +23,7 @@ import org.cryse.widget.persistentsearch.PersistentSearchView
 
 class SearchFragment : BaseFragment() {
 
-    lateinit var adapter: GenericAdapter<Novel>
-    var searchMode: Boolean = false
+    private var searchMode: Boolean = false
     private var searchTerm: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -70,7 +71,7 @@ class SearchFragment : BaseFragment() {
             activity?.drawerLayout?.openDrawer(GravityCompat.START)
         }
         searchView.setSuggestionBuilder(SuggestionsBuilder())
-        searchView.setSearchListener(object : PersistentSearchView.SearchListener {
+        val listener = object : PersistentSearchView.SearchListener {
 
             override fun onSearch(searchTerm: String?) {
                 searchTerm?.addToSearchHistory()
@@ -127,7 +128,17 @@ class SearchFragment : BaseFragment() {
                 }
                 return false
             }
-        })
+        }
+
+        // Delay setSearchListener until searchView is fully drawn
+        // Prevents the listener being called prematurely
+        searchView.viewTreeObserver.addOnGlobalFocusChangeListener(
+                object : ViewTreeObserver.OnGlobalFocusChangeListener {
+                    override fun onGlobalFocusChanged(oldFocus: View?, newFocus: View?) {
+                        searchView.viewTreeObserver.removeOnGlobalFocusChangeListener(this)
+                        searchView.setSearchListener(listener)
+                    }
+                })
     }
 
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchTermFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchTermFragment.kt
@@ -60,7 +60,7 @@ class SearchTermFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Gener
             if (savedInstanceState.containsKey("results") && savedInstanceState.containsKey("page")) {
                 items.clear()
                 @Suppress("UNCHECKED_CAST")
-                items.addAll(savedInstanceState.getSerializable("results") as java.util.ArrayList<Novel>)
+                items.addAll(savedInstanceState.getParcelableArrayList("results")!!)
                 currentPageNumber = savedInstanceState.getInt("page")
             }
         }

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchTermFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchTermFragment.kt
@@ -197,7 +197,7 @@ class SearchTermFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Gener
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         if (items.isNotEmpty())
-            outState.putSerializable("results", items)
+            outState.putParcelableArrayList("results", items)
         outState.putInt("page", currentPageNumber)
         outState.putString("searchTerm", searchTerm)
         outState.putString("resultType", resultType)

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchTermFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchTermFragment.kt
@@ -1,11 +1,11 @@
 package io.github.gmathi.novellibrary.fragment
 
 import android.os.Bundle
-import androidx.core.content.ContextCompat
-import androidx.appcompat.app.AppCompatActivity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import co.metalab.asyncawait.async
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
@@ -26,10 +26,6 @@ import java.net.URLEncoder
 
 class SearchTermFragment : BaseFragment(), GenericAdapter.Listener<Novel>, GenericAdapter.LoadMoreListener {
 
-    override var currentPageNumber: Int = 1
-    private lateinit var searchTerm: String
-    private lateinit var resultType: String
-
     companion object {
         fun newInstance(searchTerms: String, resultType: String): SearchTermFragment {
             val bundle = Bundle()
@@ -41,7 +37,10 @@ class SearchTermFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Gener
         }
     }
 
-    lateinit var adapter: GenericAdapter<Novel>
+    override var currentPageNumber: Int = 1
+    private lateinit var searchTerm: String
+    private lateinit var resultType: String
+    private lateinit var adapter: GenericAdapter<Novel>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -57,16 +56,21 @@ class SearchTermFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Gener
         //(activity as AppCompatActivity).setSupportActionBar(null)
 
         searchTerm = arguments?.getString("searchTerm")!!
+        if (savedInstanceState != null && savedInstanceState.containsKey("searchTerm"))
+            searchTerm = savedInstanceState.getString("searchTerm", searchTerm)
+
         resultType = arguments?.getString("resultType")!!
+        if (savedInstanceState != null && savedInstanceState.containsKey("resultType"))
+            resultType = savedInstanceState.getString("resultType", resultType)
 
         setRecyclerView()
 
-        if (savedInstanceState != null) {
-            if (savedInstanceState.containsKey("results")) {
-                @Suppress("UNCHECKED_CAST")
-                adapter.updateData(savedInstanceState.getSerializable("results") as java.util.ArrayList<Novel>)
-                return
-            }
+        if (savedInstanceState != null && savedInstanceState.containsKey("results") && savedInstanceState.containsKey("page")) {
+            @Suppress("UNCHECKED_CAST")
+            adapter.updateData(savedInstanceState.getSerializable("results") as java.util.ArrayList<Novel>)
+            currentPageNumber = savedInstanceState.getInt("page")
+            android.util.Log.i("MyState3", "restoring ${adapter.items.count()}/${recyclerView.adapter?.itemCount} items, currentPageNumber=$currentPageNumber, visible=$isVisible")
+            return
         }
 
         progressLayout.showLoading()
@@ -187,6 +191,9 @@ class SearchTermFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Gener
         super.onSaveInstanceState(outState)
         if (adapter.items.isNotEmpty())
             outState.putSerializable("results", adapter.items)
+        outState.putInt("page", currentPageNumber)
+        outState.putString("searchTerm", searchTerm)
+        outState.putString("resultType", resultType)
     }
 
 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchUrlFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchUrlFragment.kt
@@ -52,8 +52,7 @@ class SearchUrlFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Generi
 
             if (savedInstanceState.containsKey("results") && savedInstanceState.containsKey("page")) {
                 items.clear()
-                @Suppress("UNCHECKED_CAST")
-                items.addAll(savedInstanceState.getSerializable("results") as java.util.ArrayList<Novel>)
+                items.addAll(savedInstanceState.getParcelableArrayList("results")!!)
                 currentPageNumber = savedInstanceState.getInt("page")
             }
         }
@@ -180,8 +179,8 @@ class SearchUrlFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Generi
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         if (items.isNotEmpty())
-            outState.putSerializable("results", items)
-        outState.putSerializable("page", currentPageNumber)
+            outState.putParcelableArrayList("results", items)
+        outState.putInt("page", currentPageNumber)
         outState.putString("url", searchUrl)
     }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchUrlFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchUrlFragment.kt
@@ -1,11 +1,11 @@
 package io.github.gmathi.novellibrary.fragment
 
 import android.os.Bundle
-import androidx.core.content.ContextCompat
-import androidx.appcompat.app.AppCompatActivity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import co.metalab.asyncawait.async
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
@@ -28,6 +28,7 @@ class SearchUrlFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Generi
 
     override var currentPageNumber: Int = 1
     private lateinit var searchUrl: String
+    private lateinit var adapter: GenericAdapter<Novel>
 
     companion object {
         fun newInstance(url: String): SearchUrlFragment {
@@ -38,8 +39,6 @@ class SearchUrlFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Generi
             return fragment
         }
     }
-
-    lateinit var adapter: GenericAdapter<Novel>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -57,9 +56,14 @@ class SearchUrlFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Generi
         setRecyclerView()
 
         if (savedInstanceState != null) {
-            if (savedInstanceState.containsKey("results")) {
+            if (savedInstanceState.containsKey("url")) {
+                searchUrl = savedInstanceState.getString("url", searchUrl)
+            }
+            if (savedInstanceState.containsKey("results") && savedInstanceState.containsKey("page")) {
                 @Suppress("UNCHECKED_CAST")
                 adapter.updateData(savedInstanceState.getSerializable("results") as java.util.ArrayList<Novel>)
+                currentPageNumber = savedInstanceState.getInt("page")
+                progressLayout.showContent()
                 return
             }
         }
@@ -172,6 +176,8 @@ class SearchUrlFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Generi
         super.onSaveInstanceState(outState)
         if (adapter.items.isNotEmpty())
             outState.putSerializable("results", adapter.items)
+        outState.putSerializable("page", currentPageNumber)
+        outState.putString("url", searchUrl)
     }
 
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/WebPageDBFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/WebPageDBFragment.kt
@@ -5,7 +5,6 @@ import android.annotation.SuppressLint
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
-import androidx.core.content.ContextCompat
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,6 +12,7 @@ import android.webkit.CookieManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 import co.metalab.asyncawait.async
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -89,9 +89,9 @@ class WebPageDBFragment : BaseFragment() {
         // Get data from args or savedInstance in case of device rotation
         @Suppress("UNCHECKED_CAST")
         if (savedInstanceState != null && savedInstanceState.containsKey("webPage")) {
-            webPage = savedInstanceState.getSerializable("webPage") as WebPage
-            webPageSettings = savedInstanceState.getSerializable("webPageSettings") as WebPageSettings
-            history = savedInstanceState.getSerializable("history") as ArrayList<WebPageSettings>
+            webPage = savedInstanceState.getParcelable("webPage")
+            webPageSettings = savedInstanceState.getParcelable("webPageSettings")
+            history = savedInstanceState.getParcelableArrayList("history")!!
         } else {
             val novelId = arguments!!.getLong(NOVEL_ID)
             val sourceId = arguments!!.getLong(SOURCE_ID)
@@ -482,9 +482,9 @@ class WebPageDBFragment : BaseFragment() {
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         if (webPage != null) {
-            outState.putSerializable("webPage", webPage)
-            outState.putSerializable("webPageSettings", webPageSettings)
+            outState.putParcelable("webPage", webPage)
+            outState.putParcelable("webPageSettings", webPageSettings)
         }
-        outState.putSerializable("history", history)
+        outState.putParcelableArrayList("history", history)
     }
 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/model/Novel.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/model/Novel.kt
@@ -1,11 +1,18 @@
 package io.github.gmathi.novellibrary.model
 
-import com.google.gson.annotations.SerializedName
-import java.io.Serializable
+import android.os.Parcel
+import android.os.Parcelable
 
-class Novel(@SerializedName("name") var name: String, @SerializedName("url") var url: String) : Serializable {
+class Novel: Parcelable {
+    constructor(name: String, url: String) {
+        this.name = name
+        this.url = url
+    }
+
+    var name: String
+    var url: String
     var id: Long = -1
-    @SerializedName("imageUrl") var imageUrl: String? = null
+    var imageUrl: String? = null
     var rating: String? = null
     var shortDescription: String? = null
     var longDescription: String? = null
@@ -13,35 +20,34 @@ class Novel(@SerializedName("name") var name: String, @SerializedName("url") var
     var genres: List<String>? = null
 //    var currentWebPageId: Long = -1
 
-    @SerializedName("currentlyReading") var currentWebPageUrl: String? = null
+    var currentWebPageUrl: String? = null
     var orderId: Long = -1
     var newReleasesCount = 0L
     var chaptersCount = 0L
-    @SerializedName("metaData") var metaData: HashMap<String, String?> = HashMap()
-    @SerializedName("novelSectionId") var novelSectionId: Long = -1L
-
+    var metaData: HashMap<String, String?> = HashMap()
+    var novelSectionId: Long = -1L
 
     fun copyFrom(otherNovel: Novel?) {
         if (otherNovel != null) {
-            id = if (otherNovel.id != -1L) otherNovel.id else id
-            url = otherNovel.url
             name = otherNovel.name
-            genres = if (otherNovel.genres != null) otherNovel.genres else genres
-            rating = if (otherNovel.rating != null) otherNovel.rating else rating
+            url = otherNovel.url
+            id = if (otherNovel.id != -1L) otherNovel.id else id
             imageUrl = if (otherNovel.imageUrl != null) otherNovel.imageUrl else imageUrl
-            imageFilePath = if (otherNovel.imageFilePath != null) otherNovel.imageFilePath else imageFilePath
-            longDescription = if (otherNovel.longDescription != null) otherNovel.longDescription else longDescription
+            rating = if (otherNovel.rating != null) otherNovel.rating else rating
             shortDescription = if (otherNovel.shortDescription != null) otherNovel.shortDescription else shortDescription
+            longDescription = if (otherNovel.longDescription != null) otherNovel.longDescription else longDescription
+            imageFilePath = if (otherNovel.imageFilePath != null) otherNovel.imageFilePath else imageFilePath
+            genres = if (otherNovel.genres != null) otherNovel.genres else genres
 //            currentWebPageId = if (otherNovel.currentWebPageId != -1L) otherNovel.currentWebPageId else currentWebPageId
+
             currentWebPageUrl = if (otherNovel.currentWebPageUrl != null) otherNovel.currentWebPageUrl else currentWebPageUrl
+            orderId = if (otherNovel.orderId != -1L) otherNovel.orderId else orderId
             newReleasesCount = if (otherNovel.newReleasesCount != 0L) otherNovel.newReleasesCount else newReleasesCount
             chaptersCount = if (otherNovel.chaptersCount != 0L) otherNovel.chaptersCount else chaptersCount
-            orderId = if (otherNovel.orderId != -1L) otherNovel.orderId else orderId
-            novelSectionId = if (otherNovel.novelSectionId != -1L) otherNovel.novelSectionId else novelSectionId
-
-            otherNovel.metaData.keys.forEach {
+            otherNovel.metaData.keys.forEach{
                 metaData[it] = otherNovel.metaData[it]
             }
+            novelSectionId = if (otherNovel.novelSectionId != -1L) otherNovel.novelSectionId else novelSectionId
         }
     }
 
@@ -66,4 +72,60 @@ class Novel(@SerializedName("name") var name: String, @SerializedName("url") var
     override fun toString(): String {
         return "Novel(name='$name', url='$url', id=$id, imageUrl=$imageUrl, rating=$rating, shortDescription=$shortDescription, longDescription=$longDescription, imageFilePath=$imageFilePath, genres=$genres, currentWebPageUrl=$currentWebPageUrl, orderId=$orderId, newReleasesCount=$newReleasesCount, chaptersCount=$chaptersCount, metaData=$metaData, novelSectionId=$novelSectionId)"
     }
+
+    // region Parcelable
+    constructor(parcel: Parcel) {
+        name = parcel.readString()!!
+        url = parcel.readString()!!
+        id = parcel.readLong()
+        imageUrl = parcel.readString()
+        rating = parcel.readString()
+        shortDescription = parcel.readString()
+        longDescription = parcel.readString()
+        imageFilePath = parcel.readString()
+        genres = parcel.createStringArrayList()
+        currentWebPageUrl = parcel.readString()
+        orderId = parcel.readLong()
+        newReleasesCount = parcel.readLong()
+        chaptersCount = parcel.readLong()
+        @Suppress("UNCHECKED_CAST")
+        metaData = parcel.readSerializable() as HashMap<String, String?>
+        novelSectionId = parcel.readLong()
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeString(name)
+        parcel.writeString(url)
+        parcel.writeLong(id)
+        parcel.writeString(imageUrl)
+        parcel.writeString(rating)
+        parcel.writeString(shortDescription)
+        parcel.writeString(longDescription)
+        parcel.writeString(imageFilePath)
+        parcel.writeStringList(genres)
+//        parcel.writeLong(currentWebPageId)
+
+        parcel.writeString(currentWebPageUrl)
+        parcel.writeLong(orderId)
+        parcel.writeLong(newReleasesCount)
+        parcel.writeLong(chaptersCount)
+        parcel.writeSerializable(metaData)
+        parcel.writeLong(novelSectionId)
+    }
+
+    override fun describeContents(): Int {
+        return hashCode()
+    }
+
+    companion object CREATOR : Parcelable.Creator<Novel> {
+        override fun createFromParcel(parcel: Parcel): Novel {
+            return Novel(parcel)
+        }
+
+        override fun newArray(size: Int): Array<Novel?> {
+            return arrayOfNulls(size)
+        }
+    }
+    // endregion
+
 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/model/NovelSection.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/model/NovelSection.kt
@@ -1,3 +1,36 @@
 package io.github.gmathi.novellibrary.model
 
-data class NovelSection(var id: Long = 0, var name: String? = null, var orderId: Long = 999L)
+import android.os.Parcel
+import android.os.Parcelable
+
+data class NovelSection(var id: Long = 0, var name: String? = null, var orderId: Long = 999L) : Parcelable {
+
+    // region Parcelable
+    constructor(parcel: Parcel) : this() {
+        id = parcel.readLong()
+        name = parcel.readString()
+        orderId = parcel.readLong()
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeLong(id)
+        parcel.writeString(name)
+        parcel.writeLong(orderId)
+    }
+
+    override fun describeContents(): Int {
+        return id.toInt()
+    }
+
+    companion object CREATOR : Parcelable.Creator<NovelSection> {
+        override fun createFromParcel(parcel: Parcel): NovelSection {
+            return NovelSection(parcel)
+        }
+
+        override fun newArray(size: Int): Array<NovelSection?> {
+            return arrayOfNulls(size)
+        }
+    }
+    // endregion
+
+}

--- a/app/src/main/java/io/github/gmathi/novellibrary/model/WebPage.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/model/WebPage.kt
@@ -1,8 +1,9 @@
 package io.github.gmathi.novellibrary.model
 
-import java.io.Serializable
+import android.os.Parcel
+import android.os.Parcelable
 
-data class WebPage(var url: String, var chapter: String) : Serializable {
+data class WebPage(var url: String, var chapter: String) : Parcelable {
 
     var novelId: Long = -1L
     var sourceId: Long = -1L
@@ -28,5 +29,34 @@ data class WebPage(var url: String, var chapter: String) : Serializable {
         return "WebPage(url='$url', chapter='$chapter', novelId=$novelId, sourceId=$sourceId, orderId=$orderId)"
     }
 
+    // region Parcelable
+    constructor(parcel: Parcel) : this(parcel.readString()!!, parcel.readString()!!) {
+        novelId = parcel.readLong()
+        sourceId = parcel.readLong()
+        orderId = parcel.readLong()
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeString(url)
+        parcel.writeString(chapter)
+        parcel.writeLong(novelId)
+        parcel.writeLong(sourceId)
+        parcel.writeLong(orderId)
+    }
+
+    override fun describeContents(): Int {
+        return hashCode()
+    }
+
+    companion object CREATOR : Parcelable.Creator<WebPage> {
+        override fun createFromParcel(parcel: Parcel): WebPage {
+            return WebPage(parcel)
+        }
+
+        override fun newArray(size: Int): Array<WebPage?> {
+            return arrayOfNulls(size)
+        }
+    }
+    // endregion
 
 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/model/WebPageSettings.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/model/WebPageSettings.kt
@@ -1,8 +1,9 @@
 package io.github.gmathi.novellibrary.model
 
-import java.io.Serializable
+import android.os.Parcel
+import android.os.Parcelable
 
-data class WebPageSettings(var url: String, var novelId: Long) : Serializable {
+data class WebPageSettings(var url: String, var novelId: Long) : Parcelable {
 
     var title: String? = null
     var isRead: Int = 0
@@ -31,5 +32,40 @@ data class WebPageSettings(var url: String, var novelId: Long) : Serializable {
     override fun toString(): String {
         return "WebPageSettings(url='$url', novelId=$novelId, title=$title, isRead=$isRead, filePath=$filePath, redirectedUrl=$redirectedUrl, metaData=$metaData)"
     }
+
+    // region Parcelable
+    constructor(parcel: Parcel) : this(parcel.readString()!!, parcel.readLong()) {
+        title = parcel.readString()
+        isRead = parcel.readInt()
+        filePath = parcel.readString()
+        redirectedUrl = parcel.readString()
+        @Suppress("UNCHECKED_CAST")
+        metaData = parcel.readSerializable() as HashMap<String, String?>
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeString(url)
+        parcel.writeLong(novelId)
+        parcel.writeString(title)
+        parcel.writeInt(isRead)
+        parcel.writeString(filePath)
+        parcel.writeString(redirectedUrl)
+        parcel.writeSerializable(metaData)
+    }
+
+    override fun describeContents(): Int {
+        return hashCode()
+    }
+
+    companion object CREATOR : Parcelable.Creator<WebPageSettings> {
+        override fun createFromParcel(parcel: Parcel): WebPageSettings {
+            return WebPageSettings(parcel)
+        }
+
+        override fun newArray(size: Int): Array<WebPageSettings?> {
+            return arrayOfNulls(size)
+        }
+    }
+    // endregion
 
 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/service/sync/BackgroundNovelSyncTask.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/service/sync/BackgroundNovelSyncTask.kt
@@ -204,7 +204,7 @@ class BackgroundNovelSyncTask : GcmTaskService() {
         novelDetailsIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         val novelDetailsBundle = Bundle()
         novelDetailsBundle.putInt("currentNavId", R.id.nav_library)
-        novelDetailsBundle.putSerializable("novel", novel)
+        novelDetailsBundle.putParcelable("novel", novel)
         novelDetailsIntent.putExtras(novelDetailsBundle)
         return PendingIntent.getActivity(this.applicationContext, novel.hashCode(), novelDetailsIntent, PendingIntent.FLAG_UPDATE_CURRENT)
     }


### PR DESCRIPTION
### `__This is NOT ready to be merged__`
I just want to be transparent with the changes as I make them.

Changes:
- Updated buildToolsVersion  to 29.0.2, and kotlin from jdk7 to jdk8
- Store fragment states in activities using supportFragmentManager.putFragment/getFragment
- Move away from Serializable in favor of Parcelable, which is specially made for Android and is much faster
- Store and restore states if possible (also decrease the amount of called made to the db) _(in progress)_
- Move away from some deprecated apis _(in progress)_
- Probably fix some memory leeks _(in progress)_