### PR TITLE
Implement manual cloudflare check for novelupdates

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -125,6 +125,10 @@
             android:label="@string/title_activity_copyright"
             android:theme="@style/DarkTheme_DarkSide" />
         <activity
+            android:name=".activity.settings.CloudFlareBypassActivity"
+            android:label="@string/cloud_flare_check"
+            android:theme="@style/DarkTheme_DarkSide" />
+        <activity
             android:name=".activity.SearchUrlActivity"
             android:label="@string/title_activity_search_results"
             android:theme="@style/DarkTheme_DarkSide" />

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/CloudFlareBypassActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/CloudFlareBypassActivity.kt
@@ -1,0 +1,49 @@
+package io.github.gmathi.novellibrary.activity.settings
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.MenuItem
+import android.webkit.CookieManager
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import io.github.gmathi.novellibrary.R
+import io.github.gmathi.novellibrary.activity.BaseActivity
+import io.github.gmathi.novellibrary.network.HostNames
+import io.github.gmathi.novellibrary.util.Logs
+import kotlinx.android.synthetic.main.activity_cloudflare_bypass.*
+
+class CloudFlareBypassActivity : BaseActivity() {
+
+    private var currentHost: String = ""
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_cloudflare_bypass)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        view.settings.javaScriptEnabled = true
+        view.settings.userAgentString = HostNames.USER_AGENT
+        view.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                val cookies = CookieManager.getInstance().getCookie(url)
+                if (cookies != null && cookies.contains("cf_clearance")) {
+                    CloudFlareByPasser.saveCookies(currentHost)
+                    finish()
+                }
+            }
+        }
+        bypassHost("novelupdates.com")
+    }
+
+    fun bypassHost(url: String) {
+        currentHost = url
+        view.loadUrl("https://www.$url")
+    }
+
+    /*override fun onOptionsItemSelected(item: MenuItem?): Boolean {
+        if (item?.itemId == android.R.id.home) finish()
+        return super.onOptionsItemSelected(item)
+    }*/
+
+}

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SettingsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SettingsActivity.kt
@@ -23,6 +23,7 @@ import io.github.gmathi.novellibrary.R
 import io.github.gmathi.novellibrary.activity.BaseActivity
 import io.github.gmathi.novellibrary.adapter.GenericAdapter
 import io.github.gmathi.novellibrary.dataCenter
+import io.github.gmathi.novellibrary.extensions.startCloudFlareBypassActivity
 import io.github.gmathi.novellibrary.extensions.startGeneralSettingsActivity
 import io.github.gmathi.novellibrary.extensions.startMentionSettingsActivity
 import io.github.gmathi.novellibrary.extensions.startReaderSettingsActivity
@@ -100,6 +101,7 @@ class SettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
             getString(R.string.mentions) -> startMentionSettingsActivity()
             getString(R.string.donate_developer) -> donateDeveloperDialog()
             getString(R.string.about_us) -> aboutUsDialog()
+            getString(R.string.cloud_flare_check) -> startCloudFlareBypassActivity()
         }
     }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/extensions/Activity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/extensions/Activity.kt
@@ -151,6 +151,11 @@ fun AppCompatActivity.startContributionsActivity() {
     startActivity(intent)
 }
 
+fun AppCompatActivity.startCloudFlareBypassActivity() {
+    val intent = Intent(this, CloudFlareBypassActivity::class.java)
+    startActivity(intent)
+}
+
 fun AppCompatActivity.startImportLibraryActivity() {
     startActivityForResult(Intent(this, ImportLibraryActivity::class.java), Constants.IMPORT_LIBRARY_ACT_REQ_CODE)
 }

--- a/app/src/main/res/layout/activity_cloudflare_bypass.xml
+++ b/app/src/main/res/layout/activity_cloudflare_bypass.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="io.github.gmathi.novellibrary.activity.settings.CloudFlareBypassActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/AppTheme.PopupOverlay"/>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <WebView
+        android:id="@+id/view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -335,5 +335,6 @@
     <string name="backup_data_description">Backup the data into a ZIP archive</string>
     <string name="restore_data">Restore Data</string>
     <string name="restore_data_description">Restore data from a ZIP archive</string>
+    <string name="cloud_flare_check">CloudFlare Check</string>
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -333,6 +333,7 @@
     <string name="backup_data_description">Backup the data into a ZIP archive</string>
     <string name="restore_data">Restore Data</string>
     <string name="restore_data_description">Restore data from a ZIP archive</string>
+    <string name="cloud_flare_check">CloudFlare Check</string>
 
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -333,6 +333,7 @@
     <string name="backup_data_description">Backup the data into a ZIP archive</string>
     <string name="restore_data">Restore Data</string>
     <string name="restore_data_description">Restore data from a ZIP archive</string>
+    <string name="cloud_flare_check">CloudFlare Check</string>
 
 
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -321,5 +321,6 @@
     <string name="backup_data_description">Backup the data into a ZIP archive</string>
     <string name="restore_data">Restore Data</string>
     <string name="restore_data_description">Restore data from a ZIP archive</string>
+    <string name="cloud_flare_check">CloudFlare Check</string>
 
 </resources>

--- a/app/src/main/res/values-la/strings.xml
+++ b/app/src/main/res/values-la/strings.xml
@@ -318,6 +318,7 @@
     <string name="backup_data_description">Backup the data into a ZIP archive</string>
     <string name="restore_data">Restore Data</string>
     <string name="restore_data_description">Restore data from a ZIP archive</string>
+    <string name="cloud_flare_check">CloudFlare Check</string>
 
 
 </resources>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -259,5 +259,6 @@
     <string name="backup_file_not_found">Couldn\'t Find Th\' Backup File. Choose A New Place For Th\' Treasure!</string>
     <string name="eztracting_zip">Extractin\' Th\' ZIP Archive</string>
     <string name="simple_text_restore">Simple Text - Novel \'N Novel Sections Restore</string>
+    <string name="cloud_flare_check">CloudFlare Check</string>
 
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -328,6 +328,7 @@
     <string name="backup_data_description">Backup the data into a ZIP archive</string>
     <string name="restore_data">Restore Data</string>
     <string name="restore_data_description">Restore data from a ZIP archive</string>
+    <string name="cloud_flare_check">CloudFlare Check</string>
 
 
 </resources>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -332,6 +332,7 @@
     <string name="backup_data_description">Backup the data into a ZIP archive</string>
     <string name="restore_data">Restore Data</string>
     <string name="restore_data_description">Restore data from a ZIP archive</string>
+    <string name="cloud_flare_check">CloudFlare Check</string>
 
 
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -334,6 +334,7 @@
     <string name="backup_data_description">Backup the data into a ZIP archive</string>
     <string name="restore_data">Restore Data</string>
     <string name="restore_data_description">Restore data from a ZIP archive</string>
+    <string name="cloud_flare_check">CloudFlare Check</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
         <item>@string/mentions</item>
         <item>@string/donate_developer</item>
         <item>@string/about_us</item>
+        <item>@string/cloud_flare_check</item>
     </string-array>
 
     <string-array name="mention_settings_list" translatable="false">
@@ -297,6 +298,7 @@
     <string name="copyright_notice">Copyright Notice</string>
     <string name="donate_developer">Donate Developer</string>
     <string name="about_us">About Us</string>
+    <string name="cloud_flare_check">CloudFlare Check</string>
     <string name="libraries_used">Libraries Used</string>
     <string name="contributions">Contributions</string>
     <string name="donate">Donate</string>


### PR DESCRIPTION
Since automated cloudflare solver seem to be broken - second-best solution for the meantime.
Adds "CloudFlare Check" button to settings, which opens simple activity with WebView directing at novelupdates. When cloudflare will do it's thing - grabs clearance cookies and sends user back to main settings activity. That's it. It works.