### PR TITLE
CloudFlare workarounds

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/WebPageDBFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/WebPageDBFragment.kt
@@ -3,6 +3,7 @@ package io.github.gmathi.novellibrary.fragment
 import CloudFlareByPasser
 import android.annotation.SuppressLint
 import android.graphics.Color
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import androidx.core.content.ContextCompat
@@ -44,6 +45,7 @@ import org.jsoup.Jsoup
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.jsoup.nodes.Document
 import java.io.File
+import java.net.URL
 
 
 class WebPageDBFragment : BaseFragment() {
@@ -136,6 +138,7 @@ class WebPageDBFragment : BaseFragment() {
     private fun setWebView() {
         readerWebView.isVerticalScrollBarEnabled = dataCenter.showReaderScroll
         readerWebView.settings.javaScriptEnabled = !dataCenter.javascriptDisabled
+        readerWebView.settings.userAgentString = HostNames.USER_AGENT
         readerWebView.setBackgroundColor(Color.argb(1, 0, 0, 0))
         readerWebView.addJavascriptInterface(this, "HTMLOUT")
         readerWebView.webViewClient = object : WebViewClient() {
@@ -173,15 +176,10 @@ class WebPageDBFragment : BaseFragment() {
 
             override fun onPageFinished(view: WebView?, url: String?) {
                 val cookies = CookieManager.getInstance().getCookie(url)
-                Logs.debug("WebViewDBFragment", "All the cookiesMap in a string: $cookies")
+                Logs.debug("WebViewDBFragment", "${Uri.parse(url).host}: All the cookiesMap in a string: $cookies")
 
-                if (cookies != null && cookies.contains("cfduid") && cookies.contains("cf_clearance")) {
-                    val map: HashMap<String, String> = HashMap()
-                    val cookiesArray = cookies.split("; ")
-                    cookiesArray.forEach { cookie ->
-                        val cookieSplit = cookie.split("=")
-                        map[cookieSplit[0]] = cookieSplit[1]
-                    }
+                if (url != "about:blank" && cookies != null && cookies.contains("cfduid") && cookies.contains("cf_clearance")) {
+                    CloudFlareByPasser.saveCookies(URL(url))
                 }
 
                 webPageSettings?.let {

--- a/app/src/main/java/io/github/gmathi/novellibrary/network/CloudFlareByPasser.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/network/CloudFlareByPasser.kt
@@ -89,6 +89,10 @@ object CloudFlareByPasser {
         }
     }
 
+    fun saveCookies(url: URL): Boolean {
+        return saveCookies(url.host.replace("www.", "").replace("m.", ""))
+    }
+
     fun saveCookies(hostName: String): Boolean {
         val cookies = CookieManager.getInstance().getCookie("https://www.$hostName/").trim()
         if (cookies.contains(DataCenter.CF_COOKIES_CLEARANCE)) {

--- a/app/src/main/java/io/github/gmathi/novellibrary/network/NovelApi.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/network/NovelApi.kt
@@ -3,6 +3,7 @@ package io.github.gmathi.novellibrary.network
 import CloudFlareByPasser
 import android.net.Uri
 import io.github.gmathi.novellibrary.dataCenter
+import org.jsoup.Connection
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import java.io.IOException
@@ -14,18 +15,36 @@ import javax.net.ssl.SSLPeerUnverifiedException
 object NovelApi {
 
     fun getDocumentWithUserAgent(url: String): Document {
+        return getDocumentWithUserAgentParams(url, ignoreHttpErrors = true, ignoreContentType = false)
+    }
+
+    fun getDocumentWithUserAgentIgnoreContentType(url: String): Document {
+        return getDocumentWithUserAgentParams(url, ignoreHttpErrors = false, ignoreContentType = true)
+    }
+
+    private fun getDocumentWithUserAgentParams(url: String, ignoreHttpErrors: Boolean, ignoreContentType: Boolean): Document {
         try {
-            val doc = Jsoup
-                    .connect(url)
-                    .referrer(url)
-                    .cookies(CloudFlareByPasser.getCookieMap(URL(url)))
-                    .ignoreHttpErrors(true)
+            // Since JSoup can't load different cookies after redirect, disable them and perform redirects manually.
+            // Redirect limit here just as a safeguard in case someone decides to do infinite redirect loop.
+            var doc : Connection.Response
+            var redirectUrl = url
+            var redirectLimit = 5
+            do {
+                doc = Jsoup
+                    .connect(redirectUrl)
+                    .referrer(redirectUrl)
+                    .cookies(CloudFlareByPasser.getCookieMap(URL(redirectUrl)))
+                    .ignoreHttpErrors(ignoreHttpErrors)
+                    .ignoreContentType(ignoreContentType)
                     .timeout(30000)
                     .userAgent(HostNames.USER_AGENT)
-                    .get()
+                    .followRedirects(false)
+                    .execute()
+                if (!doc.hasHeader("location")) break
+                redirectUrl = doc.header("location")
+            } while(redirectLimit-- > 0)
 
-            return doc
-
+            return doc.parse()
         } catch (e: SSLPeerUnverifiedException) {
             val p = Pattern.compile("Hostname\\s(.*?)\\snot", Pattern.DOTALL or Pattern.CASE_INSENSITIVE or Pattern.UNICODE_CASE or Pattern.MULTILINE) // Regex for the value of the key
             val m = p.matcher(e.localizedMessage ?: "")
@@ -34,7 +53,7 @@ object NovelApi {
                 val hostNames = dataCenter.getVerifiedHosts()
                 if (!hostNames.contains(hostName ?: "")) {
                     dataCenter.saveVerifiedHost(hostName ?: "")
-                    return getDocumentWithUserAgent(url)
+                    return getDocumentWithUserAgentParams(url, ignoreHttpErrors, ignoreContentType)
                 }
             }
             throw e
@@ -43,32 +62,7 @@ object NovelApi {
                 val hostName = Uri.parse(url)?.host!!
                 if (!HostNames.isVerifiedHost(hostName)) {
                     dataCenter.saveVerifiedHost(hostName)
-                    return getDocumentWithUserAgent(url)
-                }
-            }
-            throw e
-        }
-    }
-
-    fun getDocumentWithUserAgentIgnoreContentType(url: String): Document {
-        try {
-            return Jsoup
-                    .connect(url)
-                    .referrer(url)
-                    .timeout(30000)
-                    .cookies(CloudFlareByPasser.getCookieMap(URL(url)))
-                    .userAgent(HostNames.USER_AGENT)
-                    .ignoreContentType(true)
-                    .get()
-        } catch (e: SSLPeerUnverifiedException) {
-            val p = Pattern.compile("Hostname\\s(.*?)\\snot", Pattern.DOTALL or Pattern.CASE_INSENSITIVE or Pattern.UNICODE_CASE or Pattern.MULTILINE) // Regex for the value of the key
-            val m = p.matcher(e.localizedMessage)
-            if (m.find()) {
-                val hostName = m.group(1)
-                val hostNames = dataCenter.getVerifiedHosts()
-                if (!hostNames.contains(hostName)) {
-                    dataCenter.saveVerifiedHost(hostName)
-                    return getDocumentWithUserAgent(url)
+                    return getDocumentWithUserAgentParams(url, ignoreHttpErrors, ignoreContentType)
                 }
             }
             throw e


### PR DESCRIPTION
* Unified JSoup loading methods into one.
* Disabled automatic redirect following in JSoup and implemented manual redirect. This is due to JSoup not being capable of using different cookies for different websites, hence manual redirect follow.
* Maximum redirect count is set to 5, just in case.
* When page is open in non-reader-mode - app will use same userAgent as reader mode
* Non-reader-mode cookies are now saved to perform cloudflare bypass on source websites.