### PR TITLE
Improve UX in manual cloudflare bypass

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/CloudFlareBypassActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/CloudFlareBypassActivity.kt
@@ -2,7 +2,9 @@ package io.github.gmathi.novellibrary.activity.settings
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import android.os.CountDownTimer
 import android.view.MenuItem
+import android.view.View
 import android.webkit.CookieManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -15,6 +17,7 @@ import kotlinx.android.synthetic.main.activity_cloudflare_bypass.*
 class CloudFlareBypassActivity : BaseActivity() {
 
     private var currentHost: String = ""
+    private var closeTimer: CountDownTimer? = null;
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -22,6 +25,7 @@ class CloudFlareBypassActivity : BaseActivity() {
         setContentView(R.layout.activity_cloudflare_bypass)
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        checkDone.visibility = View.GONE
         view.settings.javaScriptEnabled = true
         view.settings.userAgentString = HostNames.USER_AGENT
         view.webViewClient = object : WebViewClient() {
@@ -29,21 +33,32 @@ class CloudFlareBypassActivity : BaseActivity() {
                 val cookies = CookieManager.getInstance().getCookie(url)
                 if (cookies != null && cookies.contains("cf_clearance")) {
                     CloudFlareByPasser.saveCookies(currentHost)
-                    finish()
+                    //finish()
+                    checkState.visibility = View.GONE
+                    checkDone.visibility = View.VISIBLE
+                    closeTimer = object: CountDownTimer(3000, 4000) {
+                        override fun onTick(millisUntilFinished: Long) { }
+
+                        override fun onFinish() {
+                            finish()
+                        }
+                    }.start()
                 }
             }
         }
-        bypassHost("novelupdates.com")
+        val host = intent.getStringExtra("host")
+        if (host != null) bypassHost(host)
     }
 
-    fun bypassHost(url: String) {
+    override fun onDestroy() {
+        closeTimer?.cancel()
+        closeTimer = null
+        super.onDestroy()
+    }
+
+    private fun bypassHost(url: String) {
         currentHost = url
         view.loadUrl("https://www.$url")
     }
-
-    /*override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        if (item?.itemId == android.R.id.home) finish()
-        return super.onOptionsItemSelected(item)
-    }*/
 
 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SettingsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SettingsActivity.kt
@@ -104,7 +104,7 @@ class SettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
             getString(R.string.mentions) -> startMentionSettingsActivity()
             getString(R.string.donate_developer) -> donateDeveloperDialog()
             getString(R.string.about_us) -> aboutUsDialog()
-            getString(R.string.cloud_flare_check) -> startCloudFlareBypassActivity()
+            getString(R.string.cloud_flare_check) -> startCloudFlareBypassActivity("novelupdates.com")
         }
     }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/extensions/Activity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/extensions/Activity.kt
@@ -151,8 +151,11 @@ fun AppCompatActivity.startContributionsActivity() {
     startActivity(intent)
 }
 
-fun AppCompatActivity.startCloudFlareBypassActivity() {
+fun AppCompatActivity.startCloudFlareBypassActivity(hostName: String) {
     val intent = Intent(this, CloudFlareBypassActivity::class.java)
+    val bundle = Bundle()
+    bundle.putString("host", hostName)
+    intent.putExtras(bundle)
     startActivity(intent)
 }
 

--- a/app/src/main/res/layout/activity_cloudflare_bypass.xml
+++ b/app/src/main/res/layout/activity_cloudflare_bypass.xml
@@ -25,6 +25,23 @@
         android:id="@+id/view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" >
+
+    </WebView>
+
+    <ProgressBar
+        android:id="@+id/checkState"
+        style="@android:style/Widget.DeviceDefault.ProgressBar.Large"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:indeterminate="true" />
+
+    <ImageView
+        android:id="@+id/checkDone"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:contentDescription="@string/cloud_flare_check_complete"
+        android:tint="@color/colorStateGreen"
+        app:srcCompat="@drawable/ic_check_circle_white_vector" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,6 +299,7 @@
     <string name="donate_developer">Donate Developer</string>
     <string name="about_us">About Us</string>
     <string name="cloud_flare_check">CloudFlare Check</string>
+    <string name="cloud_flare_check_complete">Obtained CloudFlare clearance.</string>
     <string name="libraries_used">Libraries Used</string>
     <string name="contributions">Contributions</string>
     <string name="donate">Donate</string>


### PR DESCRIPTION
* Adds big-ass checkmark after obtaining clearance cookie.
* Delays automatic activity exit by 3 seconds to let the big-ass checkmark imprint onto user memory.
* Also slightly altered how activity is done, so in future it can be reused to invoke bypass for other websites.