### PR TITLE
Ahoy matey, avast our dates are mixed up!

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/LanguageActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/LanguageActivity.kt
@@ -74,7 +74,7 @@ class LanguageActivity : BaseActivity(), GenericAdapter.Listener<String> {
         }
 
         val date = Calendar.getInstance()
-        if (date.get(Calendar.MONTH) == 4 && date.get(Calendar.DAY_OF_MONTH) == 1)
+        if (date.get(Calendar.MONTH) == 3 && date.get(Calendar.DAY_OF_MONTH) == 1)
             languagesMap[resources.getString(R.string.locale_pirate)] = "pa_"
 
         val list = ArrayList(languagesMap.keys.sorted())


### PR DESCRIPTION
Ye ship arrived a month late!

I.e. fixes april fools language switch to trigger on actual april first, not on may first. Months are zero-indexed.