### PR TITLE
Implement Show Navbar at Chapter End

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/ReaderDBPagerActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/ReaderDBPagerActivity.kt
@@ -163,13 +163,7 @@ class ReaderDBPagerActivity :
 
         if (hasFocus && dataCenter.enableImmersiveMode) {
             main_content.fitsSystemWindows = false
-            val immersiveModeOptions: Int = (SYSTEM_UI_FLAG_LAYOUT_STABLE
-                    or SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                    or SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    or SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                    or SYSTEM_UI_FLAG_FULLSCREEN
-                    or SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
-            window.decorView.systemUiVisibility = immersiveModeOptions
+            window.decorView.systemUiVisibility = Constants.IMMERSIVE_MODE_FLAGS
         }
     }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/ReaderSettingsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/ReaderSettingsActivity.kt
@@ -36,12 +36,13 @@ class ReaderSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
         private const val POSITION_VOLUME_SCROLL_LENGTH = 6
         private const val POSITION_KEEP_SCREEN_ON = 7
         private const val POSITION_ENABLE_IMMERSIVE_MODE = 8
-        private const val POSITION_ENABLE_CLUSTER_PAGES = 9
-        private const val POSITION_DIRECTIONAL_LINKS = 10
-        private const val POSITION_READER_MODE_BUTTON_VISIBILITY = 11
-        private const val POSITION_KEEP_TEXT_COLOR = 12
-        private const val POSITION_ALTERNATIVE_TEXT_COLORS = 13
-        private const val POSITION_LIMIT_IMAGE_WIDTH = 14
+        private const val POSITION_SHOW_NAVBAR_AT_CHAPTER_END = 9
+        private const val POSITION_ENABLE_CLUSTER_PAGES = 10
+        private const val POSITION_DIRECTIONAL_LINKS = 11
+        private const val POSITION_READER_MODE_BUTTON_VISIBILITY = 12
+        private const val POSITION_KEEP_TEXT_COLOR = 13
+        private const val POSITION_ALTERNATIVE_TEXT_COLORS = 14
+        private const val POSITION_LIMIT_IMAGE_WIDTH = 15
     }
 
     lateinit var adapter: GenericAdapter<String>
@@ -148,6 +149,11 @@ class ReaderSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
                 itemView.widgetSwitch.visibility = View.VISIBLE
                 itemView.widgetSwitch.isChecked = dataCenter.enableImmersiveMode
                 itemView.widgetSwitch.setOnCheckedChangeListener { _, value -> dataCenter.enableImmersiveMode = value }
+            }
+            POSITION_SHOW_NAVBAR_AT_CHAPTER_END -> {
+                itemView.widgetSwitch.visibility = View.VISIBLE
+                itemView.widgetSwitch.isChecked = dataCenter.showNavbarAtChapterEnd
+                itemView.widgetSwitch.setOnCheckedChangeListener { _, value -> dataCenter.showNavbarAtChapterEnd = value }
             }
             POSITION_ENABLE_CLUSTER_PAGES -> {
                 itemView.widgetSwitch.visibility = View.VISIBLE

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/WebPageDBFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/WebPageDBFragment.kt
@@ -85,11 +85,22 @@ class WebPageDBFragment : BaseFragment() {
         val activity = activity as? ReaderDBPagerActivity ?: return
 
         // Show the menu button on scroll
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && dataCenter.isReaderModeButtonVisible)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             readerWebView.setOnScrollChangeListener { _, _, scrollY, _, oldScrollY ->
-                if (scrollY > oldScrollY && scrollY > 0) activity.menuNav.visibility = View.GONE
-                if (oldScrollY - scrollY > Constants.SCROLL_LENGTH) activity.menuNav.visibility = View.VISIBLE
+                if (dataCenter.isReaderModeButtonVisible) {
+                    if (scrollY > oldScrollY && scrollY > 0) activity.menuNav.visibility = View.GONE
+                    if (oldScrollY - scrollY > Constants.SCROLL_LENGTH) activity.menuNav.visibility = View.VISIBLE
+                }
+                if (dataCenter.enableImmersiveMode && dataCenter.showNavbarAtChapterEnd) {
+                    // Using deprecated WebView.scale due to WebViewClient.onScaleChanged being completely unreliable.
+                    // New approach sometimes simply does not trigger, causing anything but online reader mode to break.
+                    @Suppress("DEPRECATION") val height = readerWebView.contentHeight * readerWebView.scale - readerWebView.height - 10
+                    activity.window.decorView.systemUiVisibility =
+                        if (height > 0 && scrollY > height) Constants.IMMERSIVE_MODE_W_NAVBAR_FLAGS
+                        else Constants.IMMERSIVE_MODE_FLAGS
+                }
             }
+        }
 
         setWebView()
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/Constants.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/Constants.kt
@@ -1,7 +1,7 @@
 package io.github.gmathi.novellibrary.util
 
+import android.view.View.*
 import io.github.gmathi.novellibrary.BuildConfig
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Constants used by multiple classes in this package
@@ -14,6 +14,17 @@ object Constants {
     const val VOLUME_SCROLL_LENGTH_STEP = 250
     const val VOLUME_SCROLL_LENGTH_MIN = -10
     const val VOLUME_SCROLL_LENGTH_MAX = 10
+    const val IMMERSIVE_MODE_FLAGS = ( SYSTEM_UI_FLAG_LAYOUT_STABLE
+            or SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+            or SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            or SYSTEM_UI_FLAG_HIDE_NAVIGATION
+            or SYSTEM_UI_FLAG_FULLSCREEN
+            or SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+    const val IMMERSIVE_MODE_W_NAVBAR_FLAGS = ( SYSTEM_UI_FLAG_LAYOUT_STABLE
+            or SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+            or SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            or SYSTEM_UI_FLAG_FULLSCREEN
+            or SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
 
     const val DEFAULT_FONT_PATH = "/android_asset/fonts/source_sans_pro_regular.ttf"
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/DataCenter.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/DataCenter.kt
@@ -47,6 +47,7 @@ class DataCenter(context: Context) {
         private const val SCROLL_LENGTH = "scrollLength"
         private const val KEEP_SCREEN_ON = "keepScreenOn"
         private const val ENABLE_IMMERSIVE_MODE = "enableImmersiveMode"
+        private const val SHOW_NAVBAR_AT_CHAPTER_END = "showNavbarAtChapterEnd"
         private const val KEEP_TEXT_COLOR = "keepTextColor"
         private const val ALTERNATIVE_TEXT_COLORS = "alternativeTextColors"
         private const val LIMIT_IMAGE_WIDTH = "limitImageWidth"
@@ -183,6 +184,10 @@ class DataCenter(context: Context) {
     var enableImmersiveMode: Boolean
         get() = prefs.getBoolean(ENABLE_IMMERSIVE_MODE, true)
         set(value) = prefs.edit().putBoolean(ENABLE_IMMERSIVE_MODE, value).apply()
+
+    var showNavbarAtChapterEnd: Boolean
+        get() = prefs.getBoolean(SHOW_NAVBAR_AT_CHAPTER_END, true)
+        set(value) = prefs.edit().putBoolean(SHOW_NAVBAR_AT_CHAPTER_END, value).apply()
 
     var keepTextColor: Boolean
         get() = prefs.getBoolean(KEEP_TEXT_COLOR, false)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
         <item>@string/volume_scroll_length</item>
         <item>@string/keep_screen_on</item>
         <item>@string/immersive_mode</item>
+        <item>@string/show_navbar_at_chapter_end</item>
         <item>@string/merge_pages</item>
         <item>@string/directional_links</item>
         <item>@string/reader_mode_button_visibility</item>
@@ -127,6 +128,7 @@
         <item>@string/volume_scroll_length_description</item>
         <item>@string/keep_screen_on_description</item>
         <item>@string/immersive_mode_description</item>
+        <item>@string/show_navbar_at_chapter_end_description</item>
         <item>@string/merge_pages_description</item>
         <item>@string/directional_links_description</item>
         <item>@string/reader_mode_button_visibility_description</item>
@@ -429,6 +431,9 @@
 
     <string name="immersive_mode">Show Full Screen</string>
     <string name="immersive_mode_description">Hide the system bars when reading</string>
+
+    <string name="show_navbar_at_chapter_end">Show Navigation Bar At Chapter End</string>
+    <string name="show_navbar_at_chapter_end_description">Shows the navigation bar when reached the page end for phones without hardware navbar. Works only when Show Full Screen is on</string>
 
     <string name="title_reader">Reader Mode</string>
     <string name="title_night">Night Mode</string>


### PR DESCRIPTION
Adds Show Navbar at Chapter End setting. It's aimed for users that have software navbar (as in - majority of modern phones, because who does good UX nowadays?) as to reduce amount of actions required to get back from reading. This option defaults to true, since it's an UX improvement for people with software navbar, and it should not affect people with hardware navbar for obvious reasons.
Currently:
* Reach chapter end
* Swipe from bottom edge of the screen up (or from top edge down) to open navbar
* Click back

With this change:
* Reach chapter end
* Click back on appeared navbar