### PR TITLE
Add div.post-entry query parser

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/cleaner/HtmlHelper.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/cleaner/HtmlHelper.kt
@@ -79,6 +79,9 @@ open class HtmlHelper protected constructor() {
             contentElement = doc.body().getElementsByTag("div").firstOrNull { it.hasClass("panel-body") }
             if (contentElement != null) return GeneralClassTagHelper(url, "div", "panel-body", appendTitle = false)
 
+            contentElement = doc.body().getElementsByTag("div").firstOrNull { it.hasClass("post-entry") }
+            if (contentElement != null) return GeneralClassTagHelper(url, "div", "post-entry")
+
             return HtmlHelper()
         }
 


### PR DESCRIPTION
Fixes following novel:
https://www.novelupdates.com/series/the-legendary-moonlight-sculptor/
https://royalroadweed.blogspot.com/2014/11/volume-19-chapter-6.html
Implementation grabs only contents. In order to grab the title as well, query can be altered to `article.post`.