### PR TITLE
Clear new chapter counter when opening bookmark

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/LibraryFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/LibraryFragment.kt
@@ -333,6 +333,7 @@ class LibraryFragment : BaseFragment(), GenericAdapter.Listener<Novel>, SimpleIt
 
     private fun startReader(novel: Novel) {
         if (novel.currentWebPageUrl != null) {
+            dbHelper.updateNewReleasesCount(novel.id, 0L)
             (activity as? AppCompatActivity)?.startReaderDBPagerActivity(novel)
         } else {
             val confirmDialog = (activity as? AppCompatActivity)?.let {


### PR DESCRIPTION
Fixes:
> Kaithar
for some reason, I'm seeing this weird behaviour where the red "new chapter" count isn't going away after reading the new chapters (by tapping the novel image and swiping for the next chapters)
[Discord message](https://discordapp.com/channels/339610451711361024/339611422919098371/713733758863278092)

Alternatively it could be moved to `ReaderDBPagerActivity.onCreate`, but it would create unnecessary DB requests. 