### PR TITLE
Use proper CSS cleanup methods for wuxiaworld

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/cleaner/HtmlHelper.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/cleaner/HtmlHelper.kt
@@ -482,9 +482,6 @@ open class HtmlHelper protected constructor() {
      * It could be done with Android capabilities, but it seems that Color utilities do not have HSL color space (only HSV).
      */
     private fun invertColor(red: Double, green: Double, blue: Double, alpha: Double): String {
-        val rf = red / 255.0
-        val gf = green / 255.0
-        val bf = blue / 255.0
         val min = red.coerceAtMost(green).coerceAtMost(blue)
         val max = red.coerceAtLeast(green).coerceAtLeast(blue)
         val lightness = (min + max) / 2.0

--- a/app/src/main/java/io/github/gmathi/novellibrary/cleaner/WuxiaWorldHelper.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/cleaner/WuxiaWorldHelper.kt
@@ -15,12 +15,11 @@ class WuxiaWorldHelper : HtmlHelper() {
         removeCSS(doc)
         var contentElement = doc.selectFirst("div.p-15")
         contentElement?.selectFirst("div.font-resize")?.remove()
-        contentElement?.select("span[style]")?.forEach { it?.removeAttr("style") }
+        cleanCSSFromChildren(contentElement)
 
         do {
+            cleanClassAndIds(contentElement)
             contentElement?.siblingElements()?.remove()
-            contentElement?.classNames()?.forEach { contentElement?.removeClass(it) }
-            contentElement?.attr("style", "")
             contentElement = contentElement?.parent()
         } while (contentElement != null && contentElement.tagName() != "body")
         contentElement?.classNames()?.forEach { contentElement.removeClass(it) }


### PR DESCRIPTION
Updates wuxia cleaner to use up-to-date CSS cleaning methods, fixing black text issue.

Also removed unused variables in `HtmlHelper.invertColor`