### PR TITLE
Fix redirects with only local server path.

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/extensions/JavaLangExt.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/extensions/JavaLangExt.kt
@@ -71,5 +71,14 @@ inline val String.fixMalformed: String
         }
     }
 
+fun String.fixMalformedWithHost(host: String?, protocol: String?): String {
+    var url = this
+    if (url.startsWith("//"))
+        url = url.replaceFirst("//", (protocol?:"http")+"://")
+    if (host != null && url.startsWith("/"))
+        url = (protocol?:"http") + "://" + host + url
+    return url
+}
+
 inline val String?.getUrlDomain: String?
     get() = this?.let { this.toHttpUrlOrNull()?.topPrivateDomain() }

--- a/app/src/main/java/io/github/gmathi/novellibrary/network/NovelApi.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/network/NovelApi.kt
@@ -3,7 +3,7 @@ package io.github.gmathi.novellibrary.network
 import android.net.Uri
 import io.github.gmathi.novellibrary.network.proxy.BaseProxyHelper
 import io.github.gmathi.novellibrary.dataCenter
-import io.github.gmathi.novellibrary.extensions.fixMalformed
+import io.github.gmathi.novellibrary.extensions.fixMalformedWithHost
 import org.jsoup.Connection
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -75,7 +75,7 @@ object NovelApi {
                 response = connection.execute()
 
                 if (!response.hasHeader("location")) break
-                redirectUrl = response.header("location").fixMalformed
+                redirectUrl = response.header("location").fixMalformedWithHost(response.url().host, response.url().protocol)
             } while (--redirectLimit >= 0)
 
             val body = proxy?.body(response) ?: response.body()


### PR DESCRIPTION
Adds handling of `/some-local-path` redirects to be interpreted as `$protocol://$host/some-local-path`. Additionally, now uses same protocol as one used prior redirect instead of http.