### PR TITLE
Add ActiveTranslations cleaner

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/cleaner/ActiveTranslationHelper.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/cleaner/ActiveTranslationHelper.kt
@@ -1,0 +1,49 @@
+package io.github.gmathi.novellibrary.cleaner
+
+import io.github.gmathi.novellibrary.dataCenter
+import org.jsoup.nodes.Document
+
+class ActiveTranslationHelper : HtmlHelper() {
+    override fun additionalProcessing(doc: Document) {
+        // Grab the CSS that contains the rest of chapter text and preserve it.
+        val cssChapter = doc.select("div.entry-content>style").outerHtml()
+        
+        removeCSS(doc)
+        doc.head()?.getElementsByTag("style")?.remove()
+        doc.head()?.getElementsByTag("link")?.remove()
+
+        val contentElement = doc.select("div.entry-content")
+
+        contentElement.prepend("<h4>${getTitle(doc)}</h4><br>")
+
+        if (!dataCenter.enableDirectionalLinks)
+            doc.select("div.nnl_container")?.remove()
+
+        if (!dataCenter.showChapterComments) {
+            doc.getElementById("comments")?.remove()
+        }
+
+        doc.body().children().remove()
+        doc.body().classNames().forEach { doc.body().removeClass(it) }
+        doc.body().append(contentElement?.outerHtml())
+        doc.body().append(cssChapter)
+        // Restore user-select
+        // Since a lot of text is based on CSS pseudoelements, text selection is still broken,
+        // but at least it is selectable somewhat.
+        doc.body().append(
+            """
+            <style>
+                *,*::before,*::after {
+                    user-select: initial !important;
+                    
+                    top: initial!important;
+                    bottom: initial!important;
+                    left: initial!important;
+                    right: initial!important;
+                }
+            </style>
+            """.trimIndent()
+        )
+        doc.getElementById("custom-background-css")?.remove()
+    }
+}

--- a/app/src/main/java/io/github/gmathi/novellibrary/cleaner/HtmlHelper.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/cleaner/HtmlHelper.kt
@@ -45,6 +45,7 @@ open class HtmlHelper protected constructor() {
                 url.contains(HostNames.BAKA_TSUKI) -> return BakaTsukiCleaner()
                 url.contains(HostNames.SCRIBBLE_HUB) -> return ScribbleHubHelper()
                 url.contains(HostNames.NEOVEL) -> return NeovelHelper()
+                url.contains(HostNames.ACTIVE_TRANSLATIONS) -> return ActiveTranslationHelper()
             }
 
             var contentElement = doc.body().getElementsByTag("div").firstOrNull { it.hasClass("chapter-content") }
@@ -317,6 +318,9 @@ open class HtmlHelper protected constructor() {
                     width: initial !important;
                     height: initial !important;
                 }
+                svg {
+                    max-width: 100vw;
+                }
             </style>
             """.trimIndent()
         )
@@ -382,6 +386,13 @@ open class HtmlHelper protected constructor() {
                         // Image is not linking anywhere - apply zoom on click.
                         img.addEventListener("click", toggleZoom);
                     }
+                }
+                
+                // Attempt to mitigate SVGs being extremely big by limiting their size based off `viewBox` attribute.
+                var svg = document.querySelectorAll("svg");
+                for (var i = 0; i < svg.length; i++) {
+                    var s = svg[i];
+                    s.style.maxWidth = "min(100vw, " + s.viewBox.baseVal.width + "px)";
                 }
             </script>
             """.trimIndent()

--- a/app/src/main/java/io/github/gmathi/novellibrary/network/HostNames.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/network/HostNames.kt
@@ -27,6 +27,7 @@ object HostNames {
     const val FOXTELLER = "foxteller.com"
     const val BABEL_NOVEL = "babelnovel.com"
     const val NEOVEL = "neoread.neovel.io"
+    const val ACTIVE_TRANSLATIONS = "activetranslations.xyz"
 
     const val USER_AGENT = "Mozilla/5.0 (Linux; Android 5.1.1; Nexus 6 Build/LYZ28E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.84 Mobile Safari/537.36"
 


### PR DESCRIPTION
* Fixes half the chapter text being stripped out on ActiveTranslations.xyz by introducing a custom helper class.
* Fixes huge SVG icons on ActiveTranslations by adding rudimentary size limiter.