### PR TITLE
Show more detailed sync status information

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/LibraryFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/LibraryFragment.kt
@@ -293,11 +293,11 @@ class LibraryFragment : BaseFragment(), GenericAdapter.Listener<Novel>, SimpleIt
             var counter = 0
             novels.forEach {
                 try {
+                    syncDialog!!.setContent(getString(R.string.sync_fetching_chapter_counts, counter++, novels.count(), it.name))
                     val totalChapters = await { NovelApi.getChapterCount(it) }
                     if (totalChapters != 0 && totalChapters > it.chaptersCount.toInt()) {
                         totalCountMap[it] = totalChapters
                     }
-                    syncDialog!!.setContent(getString(R.string.sync_fetching_chapter_counts, ++counter, novels.count()))
                 } catch (e: Exception) {
                     Logs.error(TAG, "Novel: $it", e)
                     return@forEach
@@ -308,6 +308,7 @@ class LibraryFragment : BaseFragment(), GenericAdapter.Listener<Novel>, SimpleIt
             counter = 0
             totalCountMap.forEach {
                 val novel = it.key
+                syncDialog!!.setContent(getString(R.string.sync_fetching_chapter_list, counter++, totalCountMap.count(), novel.name))
                 novel.metaData[Constants.MetaDataKeys.LAST_UPDATED_DATE] = Utils.getCurrentFormattedDate()
                 dbHelper.updateNovelMetaData(novel)
                 dbHelper.updateChaptersAndReleasesCount(novel.id, it.value.toLong(), novel.newReleasesCount + (it.value - novel.chaptersCount))
@@ -321,7 +322,6 @@ class LibraryFragment : BaseFragment(), GenericAdapter.Listener<Novel>, SimpleIt
                         if (dbHelper.getWebPageSettings(chapters[i].url) == null)
                             dbHelper.createWebPageSettings(WebPageSettings(chapters[i].url, novel.id))
                     }
-                    syncDialog!!.setContent(getString(R.string.sync_fetching_chapter_list, ++counter, totalCountMap.count()))
 
                 } catch (e: Exception) {
                     Logs.error(TAG, "Novel: $it", e)

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/LibraryFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/LibraryFragment.kt
@@ -290,12 +290,14 @@ class LibraryFragment : BaseFragment(), GenericAdapter.Listener<Novel>, SimpleIt
             val totalCountMap: HashMap<Novel, Int> = HashMap()
 
             val novels = if (novel == null) dbHelper.getAllNovels(novelSectionId) else listOf(novel)
+            var counter = 0
             novels.forEach {
                 try {
                     val totalChapters = await { NovelApi.getChapterCount(it) }
                     if (totalChapters != 0 && totalChapters > it.chaptersCount.toInt()) {
                         totalCountMap[it] = totalChapters
                     }
+                    syncDialog!!.setContent(getString(R.string.sync_fetching_chapter_counts, ++counter, novels.count()))
                 } catch (e: Exception) {
                     Logs.error(TAG, "Novel: $it", e)
                     return@forEach
@@ -303,6 +305,7 @@ class LibraryFragment : BaseFragment(), GenericAdapter.Listener<Novel>, SimpleIt
             }
 
             //Update DB with new chapters
+            counter = 0
             totalCountMap.forEach {
                 val novel = it.key
                 novel.metaData[Constants.MetaDataKeys.LAST_UPDATED_DATE] = Utils.getCurrentFormattedDate()
@@ -318,6 +321,7 @@ class LibraryFragment : BaseFragment(), GenericAdapter.Listener<Novel>, SimpleIt
                         if (dbHelper.getWebPageSettings(chapters[i].url) == null)
                             dbHelper.createWebPageSettings(WebPageSettings(chapters[i].url, novel.id))
                     }
+                    syncDialog!!.setContent(getString(R.string.sync_fetching_chapter_list, ++counter, totalCountMap.count()))
 
                 } catch (e: Exception) {
                     Logs.error(TAG, "Novel: $it", e)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -591,7 +591,7 @@
     <!-- 0.15.6-->
     <string name="licensed_warning" tools:ignore="MissingTranslation">This novel was officially licensed by %1$s and may have missing (by DMCA or voluntary), or paywalled, chapters</string>
     
-    <string name="sync_fetching_chapter_counts">Obtaining chapter counts: %1$d / %2$d</string>
-    <string name="sync_fetching_chapter_list">Obtaining chapter lists: %1$d / %2$d</string>
+    <string name="sync_fetching_chapter_counts">Obtaining chapter counts: %1$d / %2$d\n%3$s</string>
+    <string name="sync_fetching_chapter_list">Obtaining chapter lists: %1$d / %2$d\n%3$s</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -590,5 +590,8 @@
 
     <!-- 0.15.6-->
     <string name="licensed_warning" tools:ignore="MissingTranslation">This novel was officially licensed by %1$s and may have missing (by DMCA or voluntary), or paywalled, chapters</string>
+    
+    <string name="sync_fetching_chapter_counts">Obtaining chapter counts: %1$d / %2$d</string>
+    <string name="sync_fetching_chapter_list">Obtaining chapter lists: %1$d / %2$d</string>
 
 </resources>


### PR DESCRIPTION
Now instead of ambiguous "Please wait", shows the status of the sync operation. When there's a lot of novels added to the app - sync can take some time, hence showing the counter will improve the understanding of what it does and why it takes so long.