### PR TITLE
Add support for <abbr> and footnotes

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/cleaner/GeneralQueryCleaner.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/cleaner/GeneralQueryCleaner.kt
@@ -5,7 +5,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 
 class GeneralQueryCleaner(private val url: String, private val query: String, private val appendTitle: Boolean = true,
-                          override var keepContentStyle: Boolean = false, override var keepContentIds: Boolean = false, override var keepContentClasses: Boolean = false) : HtmlCleaner() {
+                          override var keepContentStyle: Boolean = false, override var keepContentIds: Boolean = true, override var keepContentClasses: Boolean = false) : HtmlCleaner() {
 
     override fun additionalProcessing(doc: Document) {
         removeCSS(doc)


### PR DESCRIPTION
Allows to see the content of `<abbr>` tags, as well as simple algo to process footnotes. 
Because footnotes rely on tag IDs, I opted to make IDs kept by default, especially since keeping them doesn't change much but also makes in-chapter TOC to work, since `<a href="#...">` expects IDs being here. 