### PR TITLE
NovelSync API

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,13 +28,14 @@
             android:label="@string/title_activity_google_backup"
             android:screenOrientation="fullUser"
             android:theme="@style/DarkTheme_DarkSide">
-            <!--            <intent-filter>-->
-            <!--                <action android:name="android.intent.action.MAIN" />-->
 
-            <!--                <category android:name="android.intent.category.LAUNCHER" />-->
-            <!--            </intent-filter>-->
-        </activity>
-        <!-- [START fcm_default_icon] -->
+            <!-- <intent-filter> -->
+            <!-- <action android:name="android.intent.action.MAIN" /> -->
+
+
+            <!-- <category android:name="android.intent.category.LAUNCHER" /> -->
+            <!-- </intent-filter> -->
+        </activity> <!-- [START fcm_default_icon] -->
         <!--
              Set custom default icon. This is used when no icon is set for incoming notification messages.
              See README(https://goo.gl/l4GJaQ) for more.
@@ -54,7 +55,8 @@
             android:name="com.google.firebase.messaging.default_notification_channel"
             android:value="@string/default_notification_channel_id" />
 
-        <service android:name=".service.firebase.NLFirebaseMessagingService"
+        <service
+            android:name=".service.firebase.NLFirebaseMessagingService"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
@@ -165,6 +167,21 @@
         <activity
             android:name=".activity.settings.MentionSettingsActivity"
             android:label="@string/title_activity_mention_settings"
+            android:screenOrientation="fullUser"
+            android:theme="@style/DarkTheme_DarkSide" />
+        <activity
+            android:name=".activity.settings.SyncSettingsSelectionActivity"
+            android:label="@string/title_activity_sync_selection_settings"
+            android:screenOrientation="fullUser"
+            android:theme="@style/DarkTheme_DarkSide" />
+        <activity
+            android:name=".activity.settings.SyncSettingsActivity"
+            android:label="@string/title_activity_sync_settings"
+            android:screenOrientation="fullUser"
+            android:theme="@style/DarkTheme_DarkSide" />
+        <activity
+            android:name=".activity.settings.SyncLoginActivity"
+            android:label="@string/title_activity_sync_login"
             android:screenOrientation="fullUser"
             android:theme="@style/DarkTheme_DarkSide" />
         <activity

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/NovelDetailsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/NovelDetailsActivity.kt
@@ -34,6 +34,7 @@ import io.github.gmathi.novellibrary.extensions.*
 import io.github.gmathi.novellibrary.model.Novel
 import io.github.gmathi.novellibrary.network.NovelApi
 import io.github.gmathi.novellibrary.network.getNovelDetails
+import io.github.gmathi.novellibrary.network.sync.NovelSync
 import io.github.gmathi.novellibrary.util.*
 import kotlinx.android.synthetic.main.activity_novel_details.*
 import kotlinx.android.synthetic.main.content_novel_details.*
@@ -213,6 +214,7 @@ class NovelDetailsActivity : BaseActivity(), TextViewLinkHandler.OnClickListener
     private fun addNovelToDB() {
         if (novel.id == -1L) {
             novel.id = dbHelper.insertNovel(novel)
+            NovelSync.getInstance(novel)?.applyAsync { if (dataCenter.getSyncAddNovels(it.host)) it.addNovel(novel, null) }
             firebaseAnalytics.logEvent(FAC.Event.ADD_NOVEL) {
                 param(FAC.Param.NOVEL_NAME, novel.name)
                 param(FAC.Param.NOVEL_URL, novel.url)

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/ReaderDBPagerActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/ReaderDBPagerActivity.kt
@@ -40,6 +40,7 @@ import io.github.gmathi.novellibrary.dbHelper
 import io.github.gmathi.novellibrary.extensions.*
 import io.github.gmathi.novellibrary.fragment.WebPageDBFragment
 import io.github.gmathi.novellibrary.model.*
+import io.github.gmathi.novellibrary.network.sync.NovelSync
 import io.github.gmathi.novellibrary.util.Constants
 import io.github.gmathi.novellibrary.util.Constants.VOLUME_SCROLL_LENGTH_STEP
 import io.github.gmathi.novellibrary.util.Logs
@@ -149,6 +150,7 @@ class ReaderDBPagerActivity :
 
     private fun updateBookmark(webPage: WebPage) {
         dbHelper.updateBookmarkCurrentWebPageUrl(novel.id, webPage.url)
+        NovelSync.getInstance(novel)?.applyAsync { if (dataCenter.getSyncBookmarks(it.host)) it.setBookmark(novel, webPage) }
         val webPageSettings = dbHelper.getWebPageSettings(webPage.url)
         if (webPageSettings != null) {
             dbHelper.updateWebPageSettingsReadStatus(webPageSettings.url, 1, webPageSettings.metaData)

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SettingsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SettingsActivity.kt
@@ -23,10 +23,7 @@ import io.github.gmathi.novellibrary.R
 import io.github.gmathi.novellibrary.activity.BaseActivity
 import io.github.gmathi.novellibrary.adapter.GenericAdapter
 import io.github.gmathi.novellibrary.dataCenter
-import io.github.gmathi.novellibrary.extensions.startCloudFlareBypassActivity
-import io.github.gmathi.novellibrary.extensions.startGeneralSettingsActivity
-import io.github.gmathi.novellibrary.extensions.startMentionSettingsActivity
-import io.github.gmathi.novellibrary.extensions.startReaderSettingsActivity
+import io.github.gmathi.novellibrary.extensions.*
 import io.github.gmathi.novellibrary.util.CustomDividerItemDecoration
 import io.github.gmathi.novellibrary.util.applyFont
 import io.github.gmathi.novellibrary.util.setDefaults
@@ -92,7 +89,7 @@ class SettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
 
     override fun bind(item: String, itemView: View, position: Int) {
         itemView.settingsTitle.applyFont(assets).text = item
-        itemView.chevron.visibility = if (position == 0 || position == 1 || position == 2) View.VISIBLE else View.INVISIBLE
+        itemView.chevron.visibility = if (position < 4) View.VISIBLE else View.INVISIBLE
         itemView.setBackgroundColor(if (position % 2 == 0) ContextCompat.getColor(this, R.color.black_transparent)
         else ContextCompat.getColor(this, android.R.color.transparent))
     }
@@ -102,6 +99,7 @@ class SettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
             getString(R.string.general) -> startGeneralSettingsActivity()
             getString(R.string.reader) -> startReaderSettingsActivity()
             getString(R.string.mentions) -> startMentionSettingsActivity()
+            getString(R.string.sync) -> startSyncSettingsSelectionActivity()
             getString(R.string.donate_developer) -> donateDeveloperDialog()
             getString(R.string.about_us) -> aboutUsDialog()
             getString(R.string.cloud_flare_check) -> startCloudFlareBypassActivity("novelupdates.com")

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SyncLoginActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SyncLoginActivity.kt
@@ -1,0 +1,57 @@
+package io.github.gmathi.novellibrary.activity.settings
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.MenuItem
+import android.webkit.CookieManager
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import io.github.gmathi.novellibrary.R
+import io.github.gmathi.novellibrary.activity.BaseActivity
+import io.github.gmathi.novellibrary.network.CloudFlareByPasser
+import io.github.gmathi.novellibrary.network.HostNames
+import io.github.gmathi.novellibrary.util.setDefaultSettings
+import kotlinx.android.synthetic.main.activity_sync_login.*
+import java.net.URL
+
+class SyncLoginActivity : BaseActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_sync_login)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        confirm.setOnClickListener { finish() }
+
+        val url = intent.getStringExtra("url")
+        val host = URL(url).host
+        CloudFlareByPasser.clearCookies(host)
+        view.setDefaultSettings()
+        view.apply {
+            settings.apply {
+                @SuppressLint("SetJavaScriptEnabled")
+                javaScriptEnabled = true
+                userAgentString = HostNames.USER_AGENT
+            }
+            val lookup = intent.getStringExtra("lookup")?.toRegex()
+            webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    if (CloudFlareByPasser.saveLoginCookies(host, lookup!!)) {
+                        //finish()
+                        cookieStatus.text = getString(R.string.sync_cookies_found)
+                        cookieStatus.isChecked = true
+                    } else {
+                        cookieStatus.text = getString(R.string.sync_cookies_not_found)
+                        cookieStatus.isChecked = false
+                    }
+                }
+            }
+            loadUrl(url)
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) finish()
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SyncSettingsActivity.kt
@@ -1,0 +1,202 @@
+package io.github.gmathi.novellibrary.activity.settings
+
+import android.os.Bundle
+import android.view.MenuItem
+import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.DividerItemDecoration
+import co.metalab.asyncawait.async
+import com.afollestad.materialdialogs.MaterialDialog
+import io.github.gmathi.novellibrary.R
+import io.github.gmathi.novellibrary.activity.BaseActivity
+import io.github.gmathi.novellibrary.adapter.GenericAdapter
+import io.github.gmathi.novellibrary.dataCenter
+import io.github.gmathi.novellibrary.database.getAllNovelSections
+import io.github.gmathi.novellibrary.database.getAllNovels
+import io.github.gmathi.novellibrary.database.getWebPage
+import io.github.gmathi.novellibrary.dbHelper
+import io.github.gmathi.novellibrary.extensions.startSyncLoginActivity
+import io.github.gmathi.novellibrary.model.NovelSection
+import io.github.gmathi.novellibrary.network.sync.NovelSync
+import io.github.gmathi.novellibrary.util.CustomDividerItemDecoration
+import io.github.gmathi.novellibrary.util.applyFont
+import io.github.gmathi.novellibrary.util.setDefaults
+import kotlinx.android.synthetic.main.activity_settings.*
+import kotlinx.android.synthetic.main.content_recycler_view.*
+import kotlinx.android.synthetic.main.listitem_title_subtitle_widget.view.*
+import java.util.ArrayList
+
+class SyncSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
+
+    companion object {
+        const val POSITION_ENABLE = 0
+        const val POSITION_STATUS = 1
+        const val POSITION_LOG_IN = 2
+        const val POSITION_ADD_NOVELS = 3
+        const val POSITION_DELETE_NOVELS = 4
+        const val POSITION_BOOKMARKS = 5
+        const val POSITION_MAKE_SYNC = 6
+//        const val POSITION_FETCH_NOVELS = 7
+//        const val POSITION_FETCH_BOOKMARKS = 8
+//        const val POSITION_FETCH_SECTIONS = 9
+//        const val POSITION_MAKE_FETCH = 10
+        const val POSITION_FORGET = 7 // 11
+    }
+
+    lateinit var adapter: GenericAdapter<String>
+    private lateinit var settingsItems: ArrayList<String>
+    private lateinit var settingsItemsDescriptions: ArrayList<String>
+
+    private lateinit var novelSync: NovelSync
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val sync = NovelSync.getInstance(intent.getStringExtra("url")!!, true)
+        if (sync == null) {
+            finish()
+            return
+        }
+        novelSync = sync
+        setContentView(R.layout.activity_settings)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        setRecyclerView()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        adapter.notifyDataSetChanged()
+    }
+
+    private fun setRecyclerView() {
+        settingsItems = ArrayList(resources.getStringArray(R.array.sync_options).asList())
+        settingsItemsDescriptions = ArrayList(resources.getStringArray(R.array.sync_options_descriptions).asList())
+        adapter = GenericAdapter(items = settingsItems, layoutResId = R.layout.listitem_title_subtitle_widget, listener = this)
+        recyclerView.setDefaults(adapter)
+        recyclerView.addItemDecoration(CustomDividerItemDecoration(this, DividerItemDecoration.VERTICAL))
+        swipeRefreshLayout.isEnabled = false
+    }
+
+    override fun bind(item: String, itemView: View, position: Int) {
+        itemView.blackOverlay.visibility = View.INVISIBLE
+        itemView.widgetChevron.visibility = View.INVISIBLE
+        itemView.widgetSwitch.visibility = View.INVISIBLE
+        itemView.currentValue.visibility = View.INVISIBLE
+
+        itemView.title.applyFont(assets).text = item
+        itemView.subtitle.applyFont(assets).text = settingsItemsDescriptions[position]
+
+        itemView.setBackgroundColor(if (position % 2 == 0) ContextCompat.getColor(this, R.color.black_transparent)
+        else ContextCompat.getColor(this, android.R.color.transparent))
+
+        itemView.widgetSwitch.setOnCheckedChangeListener(null)
+        when(position) {
+            POSITION_ENABLE -> {
+                itemView.widgetSwitch.visibility = View.VISIBLE
+                itemView.widgetSwitch.isChecked = dataCenter.getSyncEnabled(novelSync.host)
+                itemView.widgetSwitch.setOnCheckedChangeListener { _, isChecked ->
+                    dataCenter.setSyncEnabled(novelSync.host, isChecked)
+//                    if (isChecked) {
+//                        // TODO: Ask to perform full sync if logged in
+//                    }
+                }
+            }
+            POSITION_STATUS -> {
+                itemView.widgetChevron.visibility = View.VISIBLE
+                if (novelSync.loggedIn()) {
+                    itemView.widgetChevron.setImageResource(R.drawable.ic_check_circle_white_vector)
+                    itemView.widgetChevron.imageTintList = ContextCompat.getColorStateList(this, R.color.colorStateGreen)
+                    itemView.subtitle.text = getString(R.string.logged_in)
+                } else {
+                    itemView.widgetChevron.setImageResource(R.drawable.ic_warning_white_vector)
+                    itemView.widgetChevron.imageTintList = ContextCompat.getColorStateList(this, R.color.colorStateOrange)
+                    itemView.subtitle.text = getString(R.string.not_logged_in)
+                }
+            }
+            POSITION_LOG_IN -> {
+                itemView.widgetChevron.visibility = View.VISIBLE
+            }
+            POSITION_ADD_NOVELS -> {
+                itemView.widgetSwitch.visibility = View.VISIBLE
+                itemView.widgetSwitch.isChecked = dataCenter.getSyncAddNovels(novelSync.host)
+                itemView.widgetSwitch.setOnCheckedChangeListener { _, isChecked -> dataCenter.setSyncAddNovels(novelSync.host, isChecked) }
+            }
+            POSITION_DELETE_NOVELS -> {
+                itemView.widgetSwitch.visibility = View.VISIBLE
+                itemView.widgetSwitch.isChecked = dataCenter.getSyncDeleteNovels(novelSync.host)
+                itemView.widgetSwitch.setOnCheckedChangeListener { _, isChecked -> dataCenter.setSyncDeleteNovels(novelSync.host, isChecked) }
+            }
+            POSITION_BOOKMARKS -> {
+                itemView.widgetSwitch.visibility = View.VISIBLE
+                itemView.widgetSwitch.isChecked = dataCenter.getSyncBookmarks(novelSync.host)
+                itemView.widgetSwitch.setOnCheckedChangeListener { _, isChecked -> dataCenter.setSyncBookmarks(novelSync.host, isChecked) }
+            }
+            POSITION_MAKE_SYNC -> {
+                itemView.widgetChevron.visibility = View.VISIBLE
+                itemView.widgetChevron.setImageResource(R.drawable.ic_sync_white_vector)
+            }
+            POSITION_FORGET -> {
+                itemView.widgetChevron.visibility = View.VISIBLE
+                itemView.widgetChevron.setImageResource(R.drawable.ic_delete_white_vector)
+            }
+        }
+    }
+
+    override fun onItemClick(item: String, position: Int) {
+        when (position) {
+            POSITION_LOG_IN -> startSyncLoginActivity(novelSync.getLoginURL(), novelSync.getCookieLookupRegex())
+            POSITION_MAKE_SYNC -> {
+                if (novelSync.loggedIn()) {
+                    MaterialDialog.Builder(this)
+                        .title(R.string.confirm_full_sync)
+                        .content(R.string.confirm_full_sync_description)
+                        .positiveText(R.string.okay)
+                        .negativeText(R.string.cancel)
+                        .onPositive { _, _ -> makeFullSync() }
+                        .show()
+                }
+            }
+            POSITION_FORGET -> {
+                if (novelSync.loggedIn()) {
+                    MaterialDialog.Builder(this)
+                        .title(R.string.confirm_forget_cookies)
+                        .content(R.string.confirm_forget_cookies_description)
+                        .positiveText(R.string.okay)
+                        .negativeText(R.string.cancel)
+                        .autoDismiss(true)
+                        .onPositive { _, _ ->
+                            novelSync.forget()
+                            adapter.notifyDataSetChanged()
+                        }
+                        .show()
+                }
+            }
+        }
+    }
+
+    private fun makeFullSync() {
+        val sections = dbHelper.getAllNovelSections()
+        val novels = dbHelper.getAllNovels().filter { it.url.contains(novelSync.host) }
+        val dialog = MaterialDialog.Builder(this)
+            .title(R.string.sync_in_progress)
+            .content(R.string.please_wait)
+            .progress(true, 1)
+            .show()
+
+        var counter = 0
+        val total = novels.count()
+        novelSync.batchAdd(novels, sections) { it, last ->
+            if (last) {
+                dialog.dismiss()
+            } else {
+                dialog.setTitle(getString(R.string.sync_batch_progress_title, ++counter, total))
+                dialog.setContent(getString(R.string.sync_batch_progress, it.name))
+            }
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) finish()
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SyncSettingsSelectionActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SyncSettingsSelectionActivity.kt
@@ -1,0 +1,82 @@
+package io.github.gmathi.novellibrary.activity.settings
+
+import android.os.Bundle
+import android.view.MenuItem
+import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.DividerItemDecoration
+import io.github.gmathi.novellibrary.R
+import io.github.gmathi.novellibrary.activity.BaseActivity
+import io.github.gmathi.novellibrary.adapter.GenericAdapter
+import io.github.gmathi.novellibrary.dataCenter
+import io.github.gmathi.novellibrary.extensions.startSyncSettingsActivity
+import io.github.gmathi.novellibrary.network.HostNames
+import io.github.gmathi.novellibrary.network.sync.NovelSync
+import io.github.gmathi.novellibrary.util.CustomDividerItemDecoration
+import io.github.gmathi.novellibrary.util.applyFont
+import io.github.gmathi.novellibrary.util.setDefaults
+import kotlinx.android.synthetic.main.activity_settings.*
+import kotlinx.android.synthetic.main.content_recycler_view.*
+import kotlinx.android.synthetic.main.listitem_title_subtitle.view.*
+import java.util.ArrayList
+
+class SyncSettingsSelectionActivity : BaseActivity(), GenericAdapter.Listener<String> {
+
+    lateinit var adapter: GenericAdapter<String>
+    private lateinit var settingsItems: ArrayList<String>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_settings)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        setRecyclerView()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        adapter.notifyDataSetChanged()
+    }
+
+    private fun setRecyclerView() {
+        settingsItems = ArrayList(resources.getStringArray(R.array.sync_list).asList())
+        adapter = GenericAdapter(items = settingsItems, layoutResId = R.layout.listitem_title_subtitle, listener = this)
+        recyclerView.setDefaults(adapter)
+        recyclerView.addItemDecoration(CustomDividerItemDecoration(this, DividerItemDecoration.VERTICAL))
+        swipeRefreshLayout.isEnabled = false
+    }
+
+    override fun bind(item: String, itemView: View, position: Int) {
+        itemView.title.applyFont(assets).text = item
+        val host = when(item) {
+            getString(R.string.source_novel_updates) -> HostNames.NOVEL_UPDATES
+            else -> HostNames.NOVEL_UPDATES
+        }
+
+        if (position == 0) {
+            // Disclaimer
+            itemView.subtitle.applyFont(assets).text = getString(R.string.experimental_sync_description)
+            itemView.chevron.setImageResource(R.drawable.ic_info_white_vector)
+            itemView.chevron.imageTintList = ContextCompat.getColorStateList(this, R.color.colorStateBlue)
+        } else {
+            val loggedIn = getString(if (NovelSync.getInstance(host, true)?.loggedIn() == true) R.string.logged_in else R.string.not_logged_in)
+            val enabled = getString(if(dataCenter.getSyncEnabled(host)) R.string.enabled else R.string.disabled)
+
+            itemView.subtitle.applyFont(assets).text = getString(R.string.sync_status_description, loggedIn, enabled)
+        }
+
+        itemView.setBackgroundColor(if (position % 2 == 0) ContextCompat.getColor(this, R.color.black_transparent)
+        else ContextCompat.getColor(this, android.R.color.transparent))
+    }
+
+    override fun onItemClick(item: String, position: Int) {
+        when(item) {
+            getString(R.string.source_novel_updates) -> startSyncSettingsActivity(HostNames.NOVEL_UPDATES)
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) finish()
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/app/src/main/java/io/github/gmathi/novellibrary/extensions/Activity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/extensions/Activity.kt
@@ -163,6 +163,28 @@ fun AppCompatActivity.startCloudFlareBypassActivity(hostName: String) {
     startActivity(intent)
 }
 
+fun AppCompatActivity.startSyncSettingsSelectionActivity() {
+    val intent = Intent(this, SyncSettingsSelectionActivity::class.java)
+    startActivity(intent)
+}
+
+fun AppCompatActivity.startSyncSettingsActivity(url: String) {
+    val intent = Intent(this, SyncSettingsActivity::class.java)
+    val bundle = Bundle()
+    bundle.putString("url", url)
+    intent.putExtras(bundle)
+    startActivity(intent)
+}
+
+fun AppCompatActivity.startSyncLoginActivity(url: String, lookup: String) {
+    val intent = Intent(this, SyncLoginActivity::class.java)
+    val bundle = Bundle()
+    bundle.putString("url", url)
+    bundle.putString("lookup", lookup)
+    intent.putExtras(bundle)
+    startActivity(intent)
+}
+
 fun AppCompatActivity.startImportLibraryActivity() {
     startActivityForResult(Intent(this, ImportLibraryActivity::class.java), Constants.IMPORT_LIBRARY_ACT_REQ_CODE)
 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/ChaptersFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/ChaptersFragment.kt
@@ -12,13 +12,12 @@ import com.hanks.library.AnimateCheckBox
 import io.github.gmathi.novellibrary.R
 import io.github.gmathi.novellibrary.activity.ChaptersPagerActivity
 import io.github.gmathi.novellibrary.adapter.GenericAdapterSelectTitleProvider
+import io.github.gmathi.novellibrary.dataCenter
 import io.github.gmathi.novellibrary.database.updateNovel
 import io.github.gmathi.novellibrary.dbHelper
-import io.github.gmathi.novellibrary.extensions.showEmpty
-import io.github.gmathi.novellibrary.extensions.showLoading
-import io.github.gmathi.novellibrary.extensions.startReaderDBPagerActivity
-import io.github.gmathi.novellibrary.extensions.startWebViewActivity
+import io.github.gmathi.novellibrary.extensions.*
 import io.github.gmathi.novellibrary.model.*
+import io.github.gmathi.novellibrary.network.sync.NovelSync
 import io.github.gmathi.novellibrary.util.Constants
 import io.github.gmathi.novellibrary.util.CustomDividerItemDecoration
 import io.github.gmathi.novellibrary.util.setDefaultsNoAnimation
@@ -123,6 +122,7 @@ class ChaptersFragment : BaseFragment(),
         if (novel.id != -1L) {
             novel.currentWebPageUrl = item.url
             dbHelper.updateNovel(novel)
+            NovelSync.getInstance(novel)?.applyAsync { if (dataCenter.getSyncBookmarks(it.host)) it.setBookmark(novel, item) }
             startReaderDBPagerActivity(novel, sourceId)
         } else
             startWebViewActivity(item.url)

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/LibraryFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/LibraryFragment.kt
@@ -27,6 +27,7 @@ import io.github.gmathi.novellibrary.model.WebPageSettings
 import io.github.gmathi.novellibrary.network.NovelApi
 import io.github.gmathi.novellibrary.network.getChapterCount
 import io.github.gmathi.novellibrary.network.getChapterUrls
+import io.github.gmathi.novellibrary.network.sync.NovelSync
 import io.github.gmathi.novellibrary.util.*
 import kotlinx.android.synthetic.main.content_library.*
 import kotlinx.android.synthetic.main.listitem_library.view.*
@@ -464,8 +465,10 @@ class LibraryFragment : BaseFragment(), GenericAdapter.Listener<Novel>, SimpleIt
                 else if (which != 0)
                     id = novelSections[which - 1].id
 
-                dbHelper.updateNovelSectionId(adapter.items[position].id, id)
+                val novel = adapter.items[position]
+                dbHelper.updateNovelSectionId(novel.id, id)
                 EventBus.getDefault().post(NovelSectionEvent(id))
+                NovelSync.getInstance(novel)?.applyAsync { if (dataCenter.getSyncAddNovels(it.host)) it.updateNovel(novel, novelSections.firstOrNull { section -> section.id == id }) }
                 setData()
             }
             .show()

--- a/app/src/main/java/io/github/gmathi/novellibrary/network/sync/NovelSync.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/network/sync/NovelSync.kt
@@ -1,0 +1,81 @@
+package io.github.gmathi.novellibrary.network.sync
+
+import android.webkit.CookieManager
+import co.metalab.asyncawait.async
+import io.github.gmathi.novellibrary.dataCenter
+import io.github.gmathi.novellibrary.extensions.containsCaseInsensitive
+import io.github.gmathi.novellibrary.model.Novel
+import io.github.gmathi.novellibrary.model.NovelSection
+import io.github.gmathi.novellibrary.model.WebPage
+import io.github.gmathi.novellibrary.network.HostNames
+
+abstract class NovelSync {
+
+    companion object {
+
+        fun getInstance(novel: Novel, ignoreEnabled: Boolean = false) : NovelSync? {
+            return getInstance(novel.url, ignoreEnabled)
+        }
+
+        fun getInstance(url: String, ignoreEnabled: Boolean = false) : NovelSync? {
+            return when {
+                url.containsCaseInsensitive(HostNames.NOVEL_UPDATES) && (ignoreEnabled || dataCenter.getSyncEnabled(HostNames.NOVEL_UPDATES)) -> return NovelUpdatesSync()
+                else -> null
+            }
+        }
+
+        fun getAllInstances(ignoreEnabled: Boolean = false) : List<NovelSync> {
+            val list = ArrayList<NovelSync>()
+            if(ignoreEnabled || dataCenter.getSyncEnabled(HostNames.NOVEL_UPDATES)) list.add(NovelUpdatesSync())
+            return list
+        }
+
+    }
+
+    abstract val host: String
+
+    fun forget() {
+        dataCenter.deleteLoginCookieString(host)
+        dataCenter.deleteLoginCookieString("www.$host")
+        dataCenter.deleteLoginCookieString("m.$host")
+        val manager = CookieManager.getInstance()
+        manager.setCookie("https://$host/", "")
+        manager.setCookie("https://www.$host/", "")
+        manager.setCookie("https://m.$host/", "")
+    }
+
+    fun applyAsync(predicate : (NovelSync) -> Unit) {
+        val self = this
+        async {
+            await { predicate(self) }
+        }
+    }
+
+    // Login
+    abstract fun loggedIn() : Boolean
+    abstract fun getLoginURL() : String
+    abstract fun getCookieLookupRegex() : String
+
+    // App -> Remote
+    fun addNovel(novel: Novel) : Boolean {
+        return addNovel(novel, null)
+    }
+    abstract fun addNovel(novel : Novel, section : NovelSection?) : Boolean
+    abstract fun removeNovel(novel : Novel) : Boolean
+    abstract fun updateNovel(novel : Novel, section : NovelSection?) : Boolean
+
+    fun batchAdd(novels: List<Novel>, sections: List<NovelSection>) : Boolean { return batchAdd(novels, sections, null) }
+    abstract fun batchAdd(novels: List<Novel>, sections: List<NovelSection>, predicate: ((Novel, Boolean) -> Unit)?) : Boolean
+
+    abstract fun setBookmark(novel : Novel, chapter : WebPage) : Boolean
+    abstract fun clearBookmark(novel : Novel, chapter : WebPage) : Boolean
+
+    abstract fun addSection(section : NovelSection) : Boolean
+    abstract fun removeSection(section : NovelSection) : Boolean
+    abstract fun renameSection(section : NovelSection, oldName : String?, newName : String?) : Boolean
+
+    // Remote -> App
+    abstract fun getCategories() : List<String>
+    //abstract fun getNovelsInCategory(category : NovelGenre)
+    // TODO: Remote -> app sync
+}

--- a/app/src/main/java/io/github/gmathi/novellibrary/network/sync/NovelUpdatesSync.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/network/sync/NovelUpdatesSync.kt
@@ -1,0 +1,228 @@
+package io.github.gmathi.novellibrary.network.sync
+
+import co.metalab.asyncawait.async
+import io.github.gmathi.novellibrary.database.getWebPage
+import io.github.gmathi.novellibrary.dbHelper
+import io.github.gmathi.novellibrary.model.Novel
+import io.github.gmathi.novellibrary.model.NovelGenre
+import io.github.gmathi.novellibrary.model.NovelSection
+import io.github.gmathi.novellibrary.model.WebPage
+import io.github.gmathi.novellibrary.network.CloudFlareByPasser
+import io.github.gmathi.novellibrary.network.HostNames
+import io.github.gmathi.novellibrary.network.NovelApi
+import org.jsoup.select.Elements
+import java.io.IOException
+import java.net.CookieManager
+import java.net.URL
+
+class NovelUpdatesSync : NovelSync() {
+
+    companion object {
+        const val READINGLIST_UPDATE_URL = "https://" + HostNames.NOVEL_UPDATES + "/readinglist_update.php?sid=%s&rid=%s&checked=%s"
+        const val UPDATE_NOVEL_URL = "https://" + HostNames.NOVEL_UPDATES + "/updatelist.php?sid=%s&lid=%d&act=%s"
+        const val CATEGORY_LIST_URL = "https://" + HostNames.NOVEL_UPDATES + "/create-reading-lists/"
+        const val LOGIN_URL = "https://" + HostNames.NOVEL_UPDATES + "/login/"
+        const val COOKIE_REGEX = "wordpress_(logged_in|sec|user_sw)_"
+
+        @Suppress("NOTHING_TO_INLINE")
+        inline fun validateNovel(novel : Novel) {
+            if (!novel.metaData.containsKey("PostId")) throw Exception("No PostId Found!")
+            //if (!novel.url.contains(HostNames.NOVEL_UPDATES)) throw Exception("Not a NU novel!")
+        }
+    }
+
+    override val host: String = HostNames.NOVEL_UPDATES
+
+    override fun loggedIn(): Boolean {
+        val testReg = COOKIE_REGEX.toRegex()
+        return CloudFlareByPasser.getCookieMap(URL("https://" + HostNames.NOVEL_UPDATES)).any {
+            testReg.containsMatchIn(it.key)
+        }
+    }
+
+    override fun getLoginURL(): String {
+        return LOGIN_URL
+    }
+
+    override fun getCookieLookupRegex(): String {
+        return COOKIE_REGEX
+    }
+
+    override fun addNovel(novel: Novel, section : NovelSection?) : Boolean {
+        validateNovel(novel)
+
+        val category = getSectionIndex(section)
+        return try {
+            NovelApi.getString(UPDATE_NOVEL_URL.format(novel.metaData["PostId"], category, "move"), ignoreHttpErrors = false)
+            true;
+        } catch (e : IOException) {
+            false;
+        }
+    }
+
+    override fun removeNovel(novel: Novel) : Boolean {
+        validateNovel(novel)
+
+        return try {
+            NovelApi.getString(READINGLIST_UPDATE_URL.format(novel.metaData["PostId"], "0", "noo"), ignoreHttpErrors = false)
+            true;
+        } catch (e : IOException) {
+            false;
+        }
+    }
+
+    override fun updateNovel(novel: Novel, section : NovelSection?) : Boolean {
+        return addNovel(novel, section)
+    }
+
+    override fun batchAdd(novels: List<Novel>, sections: List<NovelSection>, predicate: ((Novel, Boolean) -> Unit)?): Boolean {
+        async {
+
+            val categories = ArrayList(await { fetchCategories() })
+            val categoryMap = HashMap<Long, Int>()
+            val initialCategoryCount = categories.count()
+
+            sections.forEach { section ->
+                val name = section.name ?: "NL Section ${section.id}"
+                var index = categories.indexOfFirst { cat -> cat.name == name }
+                if (index == -1) {
+                    index = categories.count()
+                    categories.add(CategoryInfo(name))
+                }
+                categoryMap[section.id] = index
+            }
+
+            if (initialCategoryCount != categories.count()) {
+                if (!await { setCategories(categories) }) return@async
+            }
+
+            novels.forEach { novel ->
+                try {
+                    if (predicate != null) predicate(novel, false)
+                    await { NovelApi.getString(UPDATE_NOVEL_URL.format(novel.metaData["PostId"], categoryMap[novel.novelSectionId] ?: 0, "move"), ignoreHttpErrors = false) }
+                    novel.currentWebPageUrl?.let {
+                        await { setBookmark(novel, dbHelper.getWebPage(it)?:return@await) }
+                    }
+                } catch (e: IOException) {
+                    return@async
+                }
+            }
+            if (predicate != null) predicate(novels.first(), true)
+        }
+        return true
+    }
+
+    override fun setBookmark(novel: Novel, chapter : WebPage) : Boolean {
+        validateNovel(novel)
+
+        return try {
+            val chapterId = chapter.url.split("/").dropLastWhile { it.isEmpty() }.last()
+            NovelApi.getString(READINGLIST_UPDATE_URL.format(novel.metaData["PostId"], chapterId, "yes"), ignoreHttpErrors = false)
+            true;
+        } catch (e : IOException) {
+            false;
+        }
+    }
+
+    override fun clearBookmark(novel: Novel, chapter : WebPage) : Boolean {
+        validateNovel(novel)
+
+        return try {
+            NovelApi.getString(READINGLIST_UPDATE_URL.format(novel.metaData["PostId"], "0", "no"), ignoreHttpErrors = false)
+            true;
+        } catch (e : IOException) {
+            false;
+        }
+    }
+
+    override fun addSection(section: NovelSection): Boolean {
+        return setCategories(fetchCategories() + CategoryInfo(section.name?:"NL Section ${section.id}"))
+    }
+
+    override fun removeSection(section: NovelSection): Boolean {
+        val name = section.name?:"NL Section ${section.id}"
+        return setCategories(fetchCategories().filter { it.name != name })
+    }
+
+    override fun renameSection(section: NovelSection, oldName : String?, newName : String?): Boolean {
+        val categories = fetchCategories()
+        val existing = categories.firstOrNull { it.name == oldName }
+        return if (existing == null) {
+//            setCategories(categories + CategoryInfo(section.name?:"NL Section ${section.id}"))
+            false
+        } else {
+            existing.name = newName?:"NL Section ${section.id}"
+            setCategories(categories)
+        }
+    }
+
+    // getters
+
+    override fun getCategories(): List<String> {
+        return NovelApi.getDocument(CATEGORY_LIST_URL).body().select("#myTable_crl tbody tr input[name^=fname]").map {
+            it.attr("value")
+        }
+    }
+
+    // internal
+
+    private fun getSectionIndex(section : NovelSection?) : Int {
+        return if (section == null) {
+            0
+        } else {
+            val categories = fetchCategories()
+            val existingIndex = categories.firstOrNull { it.name == section.name }?.index
+            if (existingIndex != null) existingIndex
+            else {
+                setCategories(categories + CategoryInfo(section.name?:"NL Section ${section.id}"))
+                categories.count()
+            }
+        }
+    }
+
+    private fun setCategories(categories : List<CategoryInfo>) : Boolean {
+        val toKeep = mutableListOf<Int>()
+        val toDelete = mutableListOf<Int>()
+        val data = HashMap<String, String>()
+
+        val url = StringBuilder(CATEGORY_LIST_URL)
+
+        categories.forEachIndexed { index, it ->
+            it.index = index
+            if (it.keep) toKeep.add(index)
+            else toDelete.add(index)
+            data["fname$index"] = it.name
+            data["desc$index"] = it.description
+            data["webmenu$index"] = it.icon
+        }
+        data["elements_st_unchecked"] = toKeep.joinToString(",")
+        data["elements_st_checked"] = toDelete.joinToString(",")
+        return try {
+            NovelApi.getStringWithFormData(CATEGORY_LIST_URL, data, ignoreHttpErrors = false)
+            true;
+        } catch (e : IOException) {
+            false;
+        }
+    }
+
+    private fun fetchCategories() : List<CategoryInfo> {
+        return NovelApi.getDocument(CATEGORY_LIST_URL).body().select("#myTable_crl tbody tr").map {
+            CategoryInfo(
+                it.select("input[name^=fname]").attr("value"),
+                description = it.select("input[name^=desc]").attr("value"),
+                icon = it.select("select.webmenu>option[selected]").attr("value"),
+                index = it.select("input[name=check]").attr("value").toInt()
+            )
+        }
+    }
+
+    class CategoryInfo(var name : String, var description : String = "NovelLibrary section", var icon : String = "default_rl.png", var index : Int = 0) {
+
+        var keep = true
+
+        override fun toString() : String {
+            return "fname$index=$name&description$index=$description&webmenu$index=$icon"
+        }
+
+    }
+}

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/DataCenter.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/DataCenter.kt
@@ -62,6 +62,7 @@ class DataCenter(context: Context) {
         private const val DEVELOPER = "developer"
         private const val DISABLE_WUXIA_DOWNLOADS = "disableWuxiaDownloads"
         private const val HAS_ALREADY_DELETED_OLD_CHANNELS = "hasAlreadyDeletedOldChannels"
+        private const val LOGIN_COOKIES_STRING = "loginCookiesString"
 
         //Backup
         private const val LAST_LOCAL_BACKUP_TIMESTAMP = "lastLocalBackupTimestamp"
@@ -84,6 +85,12 @@ class DataCenter(context: Context) {
 
         const val READ_ALOUD_NEXT_CHAPTER = "readAloudNextChapter"
         const val SCROLLING_TEXT = "scrollingText"
+
+        // Sync
+        const val SYNC_ENABLE = "sync_enable_"
+        const val SYNC_ADD_NOVELS = "sync_add_novels_"
+        const val SYNC_DELETE_NOVELS = "sync_delete_novels_"
+        const val SYNC_BOOKMARKS = "sync_bookmarks_"
 
     }
 
@@ -294,6 +301,50 @@ class DataCenter(context: Context) {
 
     fun setCFCookiesString(hostName: String, value: String) {
         prefs.edit().putString(CF_COOKIES_STRING + hostName, value).apply()
+    }
+
+    fun getLoginCookiesString(hostName: String): String {
+        return prefs.getString(LOGIN_COOKIES_STRING + hostName, "")!!;
+    }
+
+    fun setLoginCookiesString(hostName: String, value: String) {
+        prefs.edit().putString(LOGIN_COOKIES_STRING + hostName, value).apply()
+    }
+
+    fun deleteLoginCookieString(hostName: String) {
+        prefs.edit().remove(LOGIN_COOKIES_STRING + hostName).apply()
+    }
+
+    fun getSyncEnabled(name: String): Boolean {
+        return prefs.getBoolean(SYNC_ENABLE + name, false)
+    }
+
+    fun setSyncEnabled(name: String, value: Boolean) {
+        prefs.edit().putBoolean(SYNC_ENABLE + name, value).apply()
+    }
+
+    fun getSyncAddNovels(name: String): Boolean {
+        return prefs.getBoolean(SYNC_ADD_NOVELS + name, true)
+    }
+
+    fun setSyncAddNovels(name: String, value: Boolean) {
+        prefs.edit().putBoolean(SYNC_ADD_NOVELS + name, value).apply()
+    }
+
+    fun getSyncDeleteNovels(name: String): Boolean {
+        return prefs.getBoolean(SYNC_DELETE_NOVELS + name, true)
+    }
+
+    fun setSyncDeleteNovels(name: String, value: Boolean) {
+        prefs.edit().putBoolean(SYNC_DELETE_NOVELS + name, value).apply()
+    }
+
+    fun getSyncBookmarks(name: String): Boolean {
+        return prefs.getBoolean(SYNC_BOOKMARKS + name, true)
+    }
+
+    fun setSyncBookmarks(name: String, value: Boolean) {
+        prefs.edit().putBoolean(SYNC_BOOKMARKS + name, value).apply()
     }
 
     //Backup

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/Utils.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/Utils.kt
@@ -26,12 +26,14 @@ import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.afollestad.materialdialogs.MaterialDialog
 import io.github.gmathi.novellibrary.BuildConfig
 import io.github.gmathi.novellibrary.R
+import io.github.gmathi.novellibrary.dataCenter
 import io.github.gmathi.novellibrary.database.getNovel
 import io.github.gmathi.novellibrary.dbHelper
 import io.github.gmathi.novellibrary.extensions.createFileIfNotExists
 import io.github.gmathi.novellibrary.extensions.getOrCreateDirectory
 import io.github.gmathi.novellibrary.extensions.getOrCreateFile
 import io.github.gmathi.novellibrary.model.Novel
+import io.github.gmathi.novellibrary.network.sync.NovelSync
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.safety.Whitelist
@@ -123,6 +125,7 @@ object Utils {
         val novelDir = getNovelDir(hostDir, novel.name)
         novelDir.deleteRecursively()
         dbHelper.cleanupNovelData(novel)
+        NovelSync.getInstance(novel)?.applyAsync { if (dataCenter.getSyncDeleteNovels(it.host)) it.removeNovel(novel) }
         broadcastNovelDelete(context, novel)
     }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/viewmodel/ChaptersViewModel.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/viewmodel/ChaptersViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.*
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import io.github.gmathi.novellibrary.dataCenter
 import io.github.gmathi.novellibrary.database.*
 import io.github.gmathi.novellibrary.dbHelper
 import io.github.gmathi.novellibrary.model.Download
@@ -12,6 +13,7 @@ import io.github.gmathi.novellibrary.model.WebPage
 import io.github.gmathi.novellibrary.model.WebPageSettings
 import io.github.gmathi.novellibrary.network.NovelApi
 import io.github.gmathi.novellibrary.network.getChapterUrls
+import io.github.gmathi.novellibrary.network.sync.NovelSync
 import io.github.gmathi.novellibrary.util.Constants
 import io.github.gmathi.novellibrary.util.Logs
 import io.github.gmathi.novellibrary.util.Utils
@@ -165,7 +167,7 @@ class ChaptersViewModel(private val state: SavedStateHandle) : ViewModel(), Life
         if (novel.id != -1L) return
         loadingStatus.value = Constants.Status.START
         novel.id = dbHelper.insertNovel(novel)
-
+        NovelSync.getInstance(novel)?.applyAsync { if (dataCenter.getSyncAddNovels(it.host)) it.addNovel(novel) }
         //There is a chance that the above insertion might fail
         if (novel.id == -1L) return
         chapters?.forEach { it.novelId = novel.id }

--- a/app/src/main/res/layout/activity_sync_login.xml
+++ b/app/src/main/res/layout/activity_sync_login.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="io.github.gmathi.novellibrary.activity.settings.SyncLoginActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/AppTheme.PopupOverlay" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <WebView
+            android:id="@+id/view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_gravity="fill"
+            app:layout_constraintBottom_toTopOf="@id/bottomBar"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+        </WebView>
+
+        <LinearLayout
+            android:id="@+id/bottomBar"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <CheckBox
+                android:id="@+id/cookieStatus"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:clickable="false"
+                android:editable="false"
+                android:focusable="false"
+                android:text="@string/sync_cookies_not_found" />
+
+            <Button
+                android:id="@+id/confirm"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/close" />
+
+
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,33 +30,71 @@
    -->
 
     <string-array name="search_results_tab_titles" translatable="false">
-        <item>Novel-Updates</item>
-        <item>WLN-Updates</item>
-        <item>LNMTL</item>
+        <item>@string/source_novel_updates</item>
+        <item>@string/source_wln_updates</item>
+        <item>@string/source_lnmtl</item>
     </string-array>
 
     <string-array name="search_results_tab_titles_unlocked" translatable="false">
-        <item>Novel-Updates</item>
-        <item>RoyalRoad</item>
-        <item>WLN-Updates</item>
-        <item>LNMTL</item>
+        <item>@string/source_novel_updates</item>
+        <item>@string/source_royalroad</item>
+        <item>@string/source_wln_updates</item>
+        <item>@string/source_lnmtl</item>
     </string-array>
 
     <string-array name="search_results_tab_titles_developer_only" translatable="false">
-        <item>Novel-Updates</item>
-        <item>RoyalRoad</item>
-        <item>NovelFull</item>
-        <item>WLN-Updates</item>
-        <item>LNMTL</item>
+        <item>@string/source_novel_updates</item>
+        <item>@string/source_royalroad</item>
+        <item>@string/source_novelfull</item>
+        <item>@string/source_wln_updates</item>
+        <item>@string/source_lnmtl</item>
     </string-array>
 
     <string-array name="settings_list" translatable="false">
         <item>@string/general</item>
         <item>@string/reader</item>
         <item>@string/mentions</item>
+        <item>@string/sync</item>
         <item>@string/donate_developer</item>
         <item>@string/about_us</item>
         <item>@string/cloud_flare_check</item>
+    </string-array>
+
+    <string-array name="sync_list" translatable="false">
+        <item>@string/experimental_sync_disclaimer</item>
+        <item>@string/source_novel_updates</item>
+<!--        <item>@string/source_wln_updates</item>-->
+<!--        <item>@string/source_lnmtl</item>-->
+    </string-array>
+
+    <string-array name="sync_options" translatable="false">
+        <item>@string/enable_sync</item>
+        <item>@string/sync_status</item>
+        <item>@string/sync_log_in</item>
+        <item>@string/sync_add_novels</item>
+        <item>@string/sync_delete_novels</item>
+        <item>@string/sync_bookmarks</item>
+        <item>@string/make_full_sync</item>
+<!--        <item>@string/fetch_novels</item>-->
+<!--        <item>@string/fetch_bookmarks</item>-->
+<!--        <item>@string/fetch_sections</item>-->
+<!--        <item>@string/make_full_fetch</item>-->
+        <item>@string/sync_forget</item>
+    </string-array>
+
+    <string-array name="sync_options_descriptions" translatable="false">
+        <item>@string/enable_sync_description</item>
+        <item>@string/enable_sync_description</item>
+        <item>@string/sync_log_in_description</item>
+        <item>@string/sync_add_novels_description</item>
+        <item>@string/sync_delete_novels_description</item>
+        <item>@string/sync_bookmarks_description</item>
+        <item>@string/make_full_sync_description</item>
+        <!--        <item>@string/fetch_novels_description</item>-->
+        <!--        <item>@string/fetch_bookmarks_description</item>-->
+        <!--        <item>@string/fetch_sections_description</item>-->
+        <!--        <item>@string/make_full_fetch_description</item>-->
+        <item>@string/sync_forget_description</item>
     </string-array>
 
     <string-array name="mention_settings_list" translatable="false">
@@ -219,6 +257,9 @@
     <string name="title_activity_backup_n_restore_settings" translatable="false">@string/backup_and_restore</string>
     <string name="title_activity_reader_settings" translatable="false">@string/reader</string>
     <string name="title_activity_mention_settings" translatable="false">@string/mentions</string>
+    <string name="title_activity_sync_selection_settings" translatable="false">@string/sync</string>
+    <string name="title_activity_sync_settings" translatable="false">@string/sync_settings</string>
+    <string name="title_activity_sync_login" translatable="false">@string/sync_log_in_title</string>
     <string name="title_activity_chapters_new" translatable="false">@string/chapters</string>
     <string name="title_activity_import_library" translatable="false">@string/import_reading_list</string>
     <string name="title_activity_chapter_downloads" translatable="false">ChapterDownloadsActivity</string>
@@ -590,8 +631,53 @@
 
     <!-- 0.15.6-->
     <string name="licensed_warning" tools:ignore="MissingTranslation">This novel was officially licensed by %1$s and may have missing (by DMCA or voluntary), or paywalled, chapters</string>
-    
+
     <string name="sync_fetching_chapter_counts">Obtaining chapter counts: %1$d / %2$d\n%3$s</string>
     <string name="sync_fetching_chapter_list">Obtaining chapter lists: %1$d / %2$d\n%3$s</string>
+
+    <string name="source_novel_updates">Novel-Updates</string>
+    <string name="source_wln_updates">WLN-Updates</string>
+    <string name="source_lnmtl">LNMTL</string>
+    <string name="source_royalroad">RoyalRoad</string>
+    <string name="source_novelfull">NovelFull</string>
+
+    <string name="logged_in">Logged in</string>
+    <string name="not_logged_in">Not logged in</string>
+    <string name="enabled">Enabled</string>
+    <string name="disabled">Disabled</string>
+    <string name="sync_cookies_not_found">Login cookies not found</string>
+    <string name="sync_cookies_found">Login cookies found</string>
+    <string name="confirm_forget_cookies">Forget Login</string>
+    <string name="confirm_forget_cookies_description">Delete login cookies and log out from the sync source?</string>
+    <string name="confirm_full_sync">@string/make_full_sync</string>
+    <string name="confirm_full_sync_description">Add all novels and sections from the app to the list on the source website?</string>
+    <string name="sync_batch_progress_title">Sync in progress: %1$d / %2$d</string>
+    <string name="sync_batch_progress">Adding novel: %1$s</string>
+    <string name="sync_batch_progress_bookmarks">Setting bookmark: %1$s</string>
+    <string name="sync_log_in_title">Sync: Log In</string>
+    <string name="sync_settings">Sync: Settings</string>
+
+    <string name="enable_sync">Enable Sync</string>
+    <string name="enable_sync_description">Synchronize novels from this source to the lists on the source website.</string>
+    <string name="sync_status">Sync Status</string>
+    <string name="sync_status_description">%1$s, %2$s</string>
+    <string name="sync_log_in">Log In</string>
+    <string name="sync_log_in_description">Open browser to log in to the source website. Don\'t forget to hit the "Remember Me" checkbox!</string>
+    <string name="sync_add_novels">Synchronize new novels</string>
+    <string name="sync_add_novels_description">Novels added through app will be added to your list on the source website.</string>
+    <string name="sync_delete_novels">Synchronize deleted novels</string>
+    <string name="sync_delete_novels_description">Novels removed through app will be removed from your list on the source website.</string>
+    <string name="sync_bookmarks">Synchronize bookmarks</string>
+    <string name="sync_bookmarks_description">Reading chapters in the app will synchronize reading bookmark on the source website.</string>
+    <string name="make_full_sync">Perform full sync</string>
+    <string name="make_full_sync_description">Add novels and sections from the app to your lists on the source website.</string>
+    <string name="sync_forget">Forget log in</string>
+    <string name="sync_forget_description">Delete the Login cookies from the device.</string>
+
+    <string name="experimental_sync_disclaimer">Experimental feature!</string>
+    <string name="experimental_sync_description">
+        The sync feature lets you synchronize your app library with the source website.
+        Please keep in mind that this feature is experimental and currently only supports syncing from the app to the source website but not the other way around.
+    </string>
 
 </resources>


### PR DESCRIPTION
Implements an experimental sync API with NovelUpdates implementation as proof of concept.
* Generic NovelSync API that allows to add support for other websites.
* New "Sync" settings options.
* Adding and deleting of novels now synced when enabled.
* Reading now syncs bookmark position when enabled.
* Categories are supported in auto-management mode.
  * If novel added to a category that does not exists on source website it will be added automatically. But they are not deleted.
  * Renaming of categories is supported.

It's a fairly rough implementation, but at the very least it lays down a foundation for further improvement.