### PR TITLE
Custom query selectors

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/ReaderSettingsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/ReaderSettingsActivity.kt
@@ -1,6 +1,7 @@
 package io.github.gmathi.novellibrary.activity.settings
 
 import android.os.Bundle
+import android.text.InputType
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DividerItemDecoration
 import android.view.MenuItem
@@ -46,6 +47,7 @@ class ReaderSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
         private const val POSITION_ALTERNATIVE_TEXT_COLORS = 15
         private const val POSITION_LIMIT_IMAGE_WIDTH = 16
         private const val POSITION_AUTO_READ_NEXT_CHAPTER = 17
+        private const val POSITION_CUSTOM_QUERY_LOOKUPS = 18
 
     }
 
@@ -197,6 +199,9 @@ class ReaderSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
                 itemView.widgetSwitch.isChecked = dataCenter.readAloudNextChapter
                 itemView.widgetSwitch.setOnCheckedChangeListener { _, value -> dataCenter.readAloudNextChapter = value }
             }
+            POSITION_CUSTOM_QUERY_LOOKUPS -> {
+                itemView.widgetChevron.visibility = View.VISIBLE
+            }
         }
 
         itemView.setBackgroundColor(if (position % 2 == 0) ContextCompat.getColor(this, R.color.black_transparent)
@@ -209,6 +214,21 @@ class ReaderSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
 //        }
         if (position == POSITION_READER_MODE_THEME) {
             startReaderBackgroundSettingsActivity()
+        } else if (position == POSITION_CUSTOM_QUERY_LOOKUPS) {
+            var lookup: CharSequence = dataCenter.customQueryLookups
+            MaterialDialog.Builder(this)
+                .title(getString(R.string.custom_query_lookups_edit))
+                .inputType(InputType.TYPE_TEXT_FLAG_IME_MULTI_LINE + InputType.TYPE_TEXT_FLAG_IME_MULTI_LINE + InputType.TYPE_CLASS_TEXT)
+                .input(getString(R.string.custom_query_lookups_hint), lookup) { _, input ->
+                    lookup = input
+                }
+                .positiveText(getString(R.string.fui_button_text_save))
+                .negativeText(getString(R.string.cancel))
+                .onPositive { widget, _ ->
+                    dataCenter.customQueryLookups = widget.inputEditText?.text.toString()
+
+                }
+                .show()
         }
     }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/ReaderSettingsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/ReaderSettingsActivity.kt
@@ -215,18 +215,14 @@ class ReaderSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
         if (position == POSITION_READER_MODE_THEME) {
             startReaderBackgroundSettingsActivity()
         } else if (position == POSITION_CUSTOM_QUERY_LOOKUPS) {
-            var lookup: CharSequence = dataCenter.customQueryLookups
             MaterialDialog.Builder(this)
                 .title(getString(R.string.custom_query_lookups_edit))
                 .inputType(InputType.TYPE_TEXT_FLAG_IME_MULTI_LINE + InputType.TYPE_TEXT_FLAG_IME_MULTI_LINE + InputType.TYPE_CLASS_TEXT)
-                .input(getString(R.string.custom_query_lookups_hint), lookup) { _, input ->
-                    lookup = input
-                }
+                .input(getString(R.string.custom_query_lookups_hint), dataCenter.customQueryLookups) { _, _ -> }
                 .positiveText(getString(R.string.fui_button_text_save))
                 .negativeText(getString(R.string.cancel))
                 .onPositive { widget, _ ->
                     dataCenter.customQueryLookups = widget.inputEditText?.text.toString()
-
                 }
                 .show()
         }

--- a/app/src/main/java/io/github/gmathi/novellibrary/model/QueryLookup.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/model/QueryLookup.kt
@@ -1,0 +1,3 @@
+package io.github.gmathi.novellibrary.model
+
+data class QueryLookup(val query: String, val appendTitleHeader: Boolean = true)

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/DataCenter.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/DataCenter.kt
@@ -62,6 +62,7 @@ class DataCenter(context: Context) {
         private const val DEVELOPER = "developer"
         private const val DISABLE_WUXIA_DOWNLOADS = "disableWuxiaDownloads"
         private const val HAS_ALREADY_DELETED_OLD_CHANNELS = "hasAlreadyDeletedOldChannels"
+        private const val CUSTOM_QUERY_LOOKUPS = "customQueryLookups"
 
         //Backup
         private const val LAST_LOCAL_BACKUP_TIMESTAMP = "lastLocalBackupTimestamp"
@@ -256,6 +257,9 @@ class DataCenter(context: Context) {
         get() = prefs.getBoolean(HAS_ALREADY_DELETED_OLD_CHANNELS, false)
         set(value) = prefs.edit().putBoolean(HAS_ALREADY_DELETED_OLD_CHANNELS, value).apply()
 
+    var customQueryLookups: String
+        get() = prefs.getString(CUSTOM_QUERY_LOOKUPS, "")!!
+        set(value) = prefs.edit().putString(CUSTOM_QUERY_LOOKUPS, value).apply()
 
     // Verified HostNames management
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
         <item>@string/alternative_text_colors</item>
         <item>@string/limit_image_width</item>
         <item>@string/auto_read_next_chapter</item>
+        <item>@string/custom_query_lookups</item>
     </string-array>
 
     <string-array name="reader_subtitles_list" translatable="false">
@@ -139,6 +140,7 @@
         <item>@string/alternative_text_colors_description</item>
         <item>@string/limit_image_width_description</item>
         <item>@string/auto_read_next_chapter_description</item>
+        <item>@string/custom_query_lookups_description</item>
     </string-array>
 
     <string-array name="reader_mode_menu_titles_list" translatable="false">
@@ -593,5 +595,10 @@
     
     <string name="sync_fetching_chapter_counts">Obtaining chapter counts: %1$d / %2$d\n%3$s</string>
     <string name="sync_fetching_chapter_list">Obtaining chapter lists: %1$d / %2$d\n%3$s</string>
+
+    <string name="custom_query_lookups">Custom Reader Mode lookups</string>
+    <string name="custom_query_lookups_description">Advanced usage: Add custom query selectors for unsupported websites in reader mode, enabling their support.</string>
+    <string name="custom_query_lookups_edit">Adding custom query selectors</string>
+    <string name="custom_query_lookups_hint">div.chapter-contents</string>
 
 </resources>


### PR DESCRIPTION
* Added a QueryLookup data class that can be used for remote control of query selectors for the generic HtmlCleaner.
* Extracted query selectors for HtmlCleaner into a separate list gated behind `getQueryLookups()`
* Added an advanced function to add custom query lookups. It's a bit crude, but does the job. This will help users in case when list cannot be updated immediately, but fix is just a matter of figuring out the query selector, so they can just put it in here until the list is updated instead of waiting unknown amount of time for the update.