### PR TITLE
Progressbars migration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -180,6 +180,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1'
 
+    implementation 'com.github.tingyik90:snackprogressbar:6.4.2'
+
     // Import the BoM for the Firebase platform
     implementation platform('com.google.firebase:firebase-bom:26.0.0')
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/ChaptersPagerActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/ChaptersPagerActivity.kt
@@ -7,7 +7,10 @@ import androidx.activity.viewModels
 import androidx.appcompat.view.ActionMode
 import androidx.lifecycle.observe
 import com.afollestad.materialdialogs.MaterialDialog
+import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.analytics.ktx.logEvent
+import com.tingyik90.snackprogressbar.SnackProgressBar
+import com.tingyik90.snackprogressbar.SnackProgressBarManager
 import io.github.gmathi.novellibrary.R
 import io.github.gmathi.novellibrary.adapter.ChaptersPageListener
 import io.github.gmathi.novellibrary.adapter.GenericFragmentStatePagerAdapter
@@ -46,12 +49,13 @@ class ChaptersPagerActivity : BaseActivity(), ActionMode.Callback {
     private var actionMode: ActionMode? = null
 
     private var confirmDialog: MaterialDialog? = null
-    private var progressDialog: MaterialDialog? = null
 
     private var maxProgress: Int = 0
     private var progressMessage = "In Progress…"
     private var isSyncing = false
 
+    private val snackProgressBarManager by lazy { Utils.createSnackProgressBarManager(findViewById(android.R.id.content), this)}
+    private var snackProgressBar: SnackProgressBar? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -65,7 +69,7 @@ class ChaptersPagerActivity : BaseActivity(), ActionMode.Callback {
             val isProgressShowing = savedInstanceState.getBoolean("isProgressShowing", false)
             if (isProgressShowing) {
                 setProgressDialog(savedInstanceState.getString("progressMessage", "In Progress…"), savedInstanceState.getInt("maxProgress", 0))
-                progressDialog?.show()
+                showProgressDialog()
             }
             novel = savedInstanceState.getSerializable("novel") as? Novel
         } else {
@@ -129,15 +133,15 @@ class ChaptersPagerActivity : BaseActivity(), ActionMode.Callback {
             //Update Action mode actions status
             when (progress) {
                 Constants.Status.START -> {
-                    progressDialog?.show()
+                    showProgressDialog()
                 }
                 Constants.Status.DONE -> {
-                    progressDialog?.dismiss()
+                    snackProgressBar = null
+                    snackProgressBarManager.dismiss()
                     EventBus.getDefault().post(ChapterActionModeEvent(eventType = EventType.COMPLETE))
                 }
                 else -> {
-                    progressDialog?.setProgress(progress.toInt())
-                    //progressDialog?.setProgressNumberFormat(progress)
+                    setProgressDialogValue(progress.toInt())
                 }
             }
         }
@@ -480,14 +484,42 @@ class ChaptersPagerActivity : BaseActivity(), ActionMode.Callback {
             .onNegative { dialog, _ -> dialog.dismiss() }
             .show()
     }
+    
+    private fun showProgressDialog() {
+        if (snackProgressBar != null) {
+            snackProgressBarManager.show(snackProgressBar!!, SnackProgressBarManager.LENGTH_INDEFINITE)
+        }
+    }
 
     private fun setProgressDialog(message: String, maxProgress: Int) {
         progressMessage = message
         this.maxProgress = maxProgress
-        progressDialog = MaterialDialog.Builder(this@ChaptersPagerActivity)
-            .content(message)
-            .progress(false, maxProgress, true)
-            .cancelable(false).build()
+
+        if (snackProgressBar != null) {
+            snackProgressBar = null
+            snackProgressBarManager.dismissAll()
+        }
+
+        if (maxProgress == 0 || maxProgress > 10) {
+            snackProgressBar = SnackProgressBar(SnackProgressBar.TYPE_HORIZONTAL, message)
+                .setProgressMax(maxProgress)
+        }
+        else {
+            showSnackbar(message)
+        }
+    }
+    
+    private fun setProgressDialogValue(progress: Int) {
+        if (snackProgressBar != null) {
+            snackProgressBarManager.setProgress(progress)
+        }
+    }
+    
+    private fun showSnackbar(message: String) {
+        val snackbar = Snackbar.make(findViewById(android.R.id.content),
+            message,
+            Snackbar.LENGTH_SHORT)
+        snackbar.show()
     }
     //endregion
 
@@ -495,7 +527,7 @@ class ChaptersPagerActivity : BaseActivity(), ActionMode.Callback {
         super.onSaveInstanceState(outState)
         outState.putInt("maxProgress", maxProgress)
         outState.putString("progressMessage", progressMessage)
-        outState.putBoolean("isProgressShowing", progressDialog?.isShowing ?: false)
+        outState.putBoolean("isProgressShowing", snackProgressBar != null)
         outState.putSerializable("novel", vm.novel)
     }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/ChaptersPagerActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/ChaptersPagerActivity.kt
@@ -53,6 +53,7 @@ class ChaptersPagerActivity : BaseActivity(), ActionMode.Callback {
     private var maxProgress: Int = 0
     private var progressMessage = "In Progress…"
     private var isSyncing = false
+    private var isChaptersProcessing = false
 
     private val snackProgressBarManager by lazy { Utils.createSnackProgressBarManager(findViewById(android.R.id.content), this)}
     private var snackProgressBar: SnackProgressBar? = null
@@ -136,6 +137,7 @@ class ChaptersPagerActivity : BaseActivity(), ActionMode.Callback {
                     showProgressDialog()
                 }
                 Constants.Status.DONE -> {
+                    isChaptersProcessing = false
                     snackProgressBar = null
                     snackProgressBarManager.dismiss()
                     EventBus.getDefault().post(ChapterActionModeEvent(eventType = EventType.COMPLETE))
@@ -492,6 +494,7 @@ class ChaptersPagerActivity : BaseActivity(), ActionMode.Callback {
     }
 
     private fun setProgressDialog(message: String, maxProgress: Int) {
+        isChaptersProcessing = true
         progressMessage = message
         this.maxProgress = maxProgress
 
@@ -529,6 +532,14 @@ class ChaptersPagerActivity : BaseActivity(), ActionMode.Callback {
         outState.putString("progressMessage", progressMessage)
         outState.putBoolean("isProgressShowing", snackProgressBar != null)
         outState.putSerializable("novel", vm.novel)
+    }
+
+    override fun onBackPressed() {
+        if (isSyncing || isChaptersProcessing) {
+            return
+        }
+
+        super.onBackPressed()
     }
 
 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/BackupSettingsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/BackupSettingsActivity.kt
@@ -203,7 +203,7 @@ class BackupSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
         super.onDestroy()
     }
 
-    private fun showDialog(title: String? = null, content: String? = null, iconRes: Int = R.drawable.ic_warning_white_vector, isProgress: Boolean = false) {
+    private fun showDialog(title: String? = null, content: String? = null, iconRes: Int = R.drawable.ic_warning_white_vector) {
         if (confirmDialog != null && confirmDialog!!.isShowing)
             confirmDialog!!.dismiss()
 
@@ -212,17 +212,13 @@ class BackupSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
         if (title != null)
             confirmDialogBuilder.title(getString(R.string.confirm_action))
 
-        if (isProgress)
-            confirmDialogBuilder.progress(true, 100)
-
         if (content != null)
             confirmDialogBuilder.content(content)
 
         confirmDialogBuilder
             .iconRes(iconRes)
 
-        if (!isProgress)
-            confirmDialogBuilder.positiveText(getString(R.string.okay)).onPositive { dialog, _ -> dialog.dismiss() }
+        confirmDialogBuilder.positiveText(getString(R.string.okay)).onPositive { dialog, _ -> dialog.dismiss() }
 
         confirmDialog = confirmDialogBuilder.build()
         confirmDialog?.show()

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/ReaderSettingsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/ReaderSettingsActivity.kt
@@ -8,6 +8,7 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DividerItemDecoration
 import com.afollestad.materialdialogs.MaterialDialog
+import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.ktx.logEvent
 import io.github.gmathi.novellibrary.R
@@ -18,6 +19,7 @@ import io.github.gmathi.novellibrary.dbHelper
 import io.github.gmathi.novellibrary.extensions.FAC
 import io.github.gmathi.novellibrary.util.Constants.VOLUME_SCROLL_LENGTH_MAX
 import io.github.gmathi.novellibrary.util.Constants.VOLUME_SCROLL_LENGTH_MIN
+import io.github.gmathi.novellibrary.util.Utils
 import io.github.gmathi.novellibrary.util.applyFont
 import io.github.gmathi.novellibrary.util.setDefaults
 import io.github.gmathi.novellibrary.util.system.startReaderBackgroundSettingsActivity
@@ -250,27 +252,23 @@ class ReaderSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
             .positiveText(R.string.clear)
             .negativeText(R.string.cancel)
             .onPositive { dialog, _ ->
-                val progressDialog = MaterialDialog.Builder(this)
-                    .title(getString(R.string.clearing_data))
-                    .content(getString(R.string.please_wait))
-                    .progress(true, 0)
-                    .cancelable(false)
-                    .canceledOnTouchOutside(false)
-                    .show()
-                deleteFiles(progressDialog)
+                val snackBar = Snackbar.make(findViewById(android.R.id.content),
+                    getString(R.string.clearing_data) +  " - " + getString(R.string.please_wait),
+                    Snackbar.LENGTH_INDEFINITE)
+                deleteFiles()
+                snackBar.dismiss()
                 dialog.dismiss()
             }
             .onNegative { dialog, _ -> dialog.dismiss() }
             .show()
     }
 
-    private fun deleteFiles(dialog: MaterialDialog) {
+    private fun deleteFiles() {
         try {
             deleteDir(cacheDir)
             deleteDir(filesDir)
             dbHelper.removeAll()
             dataCenter.saveNovelSearchHistory(ArrayList())
-            dialog.dismiss()
         } catch (e: Exception) {
             e.printStackTrace()
         }

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/SyncSettingsActivity.kt
@@ -3,9 +3,12 @@ package io.github.gmathi.novellibrary.activity.settings
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DividerItemDecoration
 import com.afollestad.materialdialogs.MaterialDialog
+import com.tingyik90.snackprogressbar.SnackProgressBar
+import com.tingyik90.snackprogressbar.SnackProgressBarManager
 import io.github.gmathi.novellibrary.R
 import io.github.gmathi.novellibrary.activity.BaseActivity
 import io.github.gmathi.novellibrary.adapter.GenericAdapter
@@ -15,8 +18,11 @@ import io.github.gmathi.novellibrary.database.getAllNovels
 import io.github.gmathi.novellibrary.dbHelper
 import io.github.gmathi.novellibrary.util.system.startSyncLoginActivity
 import io.github.gmathi.novellibrary.network.sync.NovelSync
+import io.github.gmathi.novellibrary.util.Utils
 import io.github.gmathi.novellibrary.util.view.CustomDividerItemDecoration
 import io.github.gmathi.novellibrary.util.applyFont
+import io.github.gmathi.novellibrary.util.lang.launchIO
+import io.github.gmathi.novellibrary.util.lang.launchUI
 import io.github.gmathi.novellibrary.util.setDefaults
 import kotlinx.android.synthetic.main.activity_settings.*
 import kotlinx.android.synthetic.main.content_recycler_view.*
@@ -170,25 +176,66 @@ class SyncSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> {
             }
         }
     }
+    
+    private var makeFullSyncInProgress = false
 
     private fun makeFullSync() {
-        val sections = dbHelper.getAllNovelSections()
-        val novels = dbHelper.getAllNovels().filter { it.url.contains(novelSync.host) }
-        val dialog = MaterialDialog.Builder(this)
-            .title(R.string.sync_in_progress)
-            .content(R.string.please_wait)
-            .progress(true, 1)
-            .show()
+        makeFullSyncInProgress = true
+        val view = findViewById<ViewGroup>(android.R.id.content)
+        view.isEnabled = false
+        val snackProgressBarManager = Utils.createSnackProgressBarManager(view, null)
+        val snackProgressBar = SnackProgressBar(SnackProgressBar.TYPE_HORIZONTAL, getString(R.string.sync_in_progress) + " - " + getString(R.string.please_wait))
 
-        var counter = 0
-        val total = novels.count()
-        novelSync.batchAdd(novels, sections) { novelName ->
-            if (counter == total) {
-                dialog.dismiss()
-            } else {
-                dialog.setTitle(getString(R.string.sync_batch_progress_title, ++counter, total))
-                dialog.setContent(getString(R.string.sync_batch_progress, novelName))
+        launchUI {
+            snackProgressBarManager.show(
+                snackProgressBar,
+                SnackProgressBarManager.LENGTH_INDEFINITE
+            )
+        }
+
+        launchIO {
+            val sections = dbHelper.getAllNovelSections()
+            val novels = dbHelper.getAllNovels().filter { it.url.contains(novelSync.host) }
+
+            val total = novels.count()
+
+            launchUI {
+                snackProgressBarManager.updateTo(snackProgressBar.setProgressMax(total))
             }
+
+            var counter = 0
+            novelSync.batchAdd(novels, sections) { novelName ->
+                if (++counter == total) {
+                    launchUI {
+                        snackProgressBarManager.disable()
+                        view.isEnabled = true
+                        makeFullSyncInProgress = false
+                    }
+                } else {
+                    launchUI {
+                        try {
+                            snackProgressBarManager.updateTo(
+                                snackProgressBar.setMessage(
+                                    getString(
+                                        R.string.sync_batch_progress_title,
+                                        counter,
+                                        total
+                                    ) + " - " + getString(R.string.sync_batch_progress, novelName)
+                                )
+                            )
+                            snackProgressBarManager.setProgress(counter)
+                        } catch (ex: Exception) {
+                            // Could probably fail because snackProgressBarManager became invalid
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onBackPressed() {
+        if (!makeFullSyncInProgress) {
+            super.onBackPressed()
         }
     }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/Utils.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/Utils.kt
@@ -374,16 +374,12 @@ object Utils {
         activity: AppCompatActivity,
         title: String? = null,
         content: String? = null,
-        iconRes: Int = R.drawable.ic_warning_white_vector,
-        isProgress: Boolean = false
+        iconRes: Int = R.drawable.ic_warning_white_vector
     ): MaterialDialog.Builder {
         val dialogBuilder = MaterialDialog.Builder(activity)
 
         if (title != null)
             dialogBuilder.title(activity.getString(R.string.confirm_action))
-
-        if (isProgress)
-            dialogBuilder.progress(true, 100)
 
         if (content != null)
             dialogBuilder.content(content)
@@ -391,8 +387,7 @@ object Utils {
         dialogBuilder
             .iconRes(iconRes)
 
-        if (!isProgress)
-            dialogBuilder.positiveText(activity.getString(R.string.okay)).onPositive { dialog, _ -> dialog.dismiss() }
+        dialogBuilder.positiveText(activity.getString(R.string.okay)).onPositive { dialog, _ -> dialog.dismiss() }
 
         return dialogBuilder
     }

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/Utils.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/Utils.kt
@@ -18,12 +18,15 @@ import android.os.Bundle
 import android.os.Environment
 import android.util.Log
 import android.util.TypedValue
+import android.view.View
 import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.documentfile.provider.DocumentFile
+import androidx.lifecycle.LifecycleOwner
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.afollestad.materialdialogs.MaterialDialog
+import com.tingyik90.snackprogressbar.SnackProgressBarManager
 import io.github.gmathi.novellibrary.BuildConfig
 import io.github.gmathi.novellibrary.R
 import io.github.gmathi.novellibrary.dataCenter
@@ -340,6 +343,16 @@ object Utils {
             return result // return the file size
         }
         return 0
+    }
+    
+    fun createSnackProgressBarManager(view: View, lifecycleOwner: LifecycleOwner?): SnackProgressBarManager {
+        val result = SnackProgressBarManager(view, lifecycleOwner)
+        result
+            .setProgressBarColor(R.color.colorAccent)
+            .setBackgroundColor(SnackProgressBarManager.BACKGROUND_COLOR_DEFAULT)
+            .setTextSize(14f)
+            .setMessageMaxLines(2)
+        return result
     }
 
     fun getDeviceInfo(): String {


### PR DESCRIPTION
Migrating old progress bars of materials dialogs to a snackbar with a progress indicator.
Isn't always the most clean solution for the moment, but if we want to update the UI (the app should stay responsive in the future maybe during e.g. chapter updates), this should be a good solution.