### PR TITLE
TTSfix - Read next chapter instead of first

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/ReaderDBPagerActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/ReaderDBPagerActivity.kt
@@ -413,7 +413,9 @@ class ReaderDBPagerActivity :
                     val webPageDBFragment = (binding.viewPager.adapter?.instantiateItem(binding.viewPager, binding.viewPager.currentItem) as? WebPageDBFragment)
                     val audioText = webPageDBFragment?.doc?.getFormattedText() ?: return
                     val title = webPageDBFragment.doc?.title() ?: ""
-                    startTTSService(audioText, title, novel.id, sourceId)
+                    val chapterIndex = (if (dataCenter.japSwipe) webPages.reversed() else webPages).indexOf(webPages[binding.viewPager.currentItem])
+
+                    startTTSService(audioText, title, novel.id, sourceId, chapterIndex)
                     firebaseAnalytics.logEvent(FAC.Event.LISTEN_NOVEL) {
                         param(FAC.Param.NOVEL_NAME, novel.name)
                         param(FAC.Param.NOVEL_URL, novel.url)

--- a/app/src/main/java/io/github/gmathi/novellibrary/service/tts/TTSService.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/service/tts/TTSService.kt
@@ -54,6 +54,7 @@ class TTSService : Service(), TextToSpeech.OnInitListener {
         const val TITLE = "title"
         const val NOVEL_ID = "novelId"
         const val SOURCE_ID = "sourceId"
+        const val CHAPTER_INDEX = "chapterIndex"
 
         const val ACTION_STOP = "actionStop"
         const val ACTION_PAUSE = "actionPause"
@@ -156,6 +157,7 @@ class TTSService : Service(), TextToSpeech.OnInitListener {
         audioText = intent?.extras?.getString(AUDIO_TEXT_KEY, null) ?: ""
         title = intent?.extras?.getString(TITLE, null) ?: ""
         sourceId = intent?.extras?.getLong(SOURCE_ID, 0L) ?: 0L
+        chapterIndex = intent?.extras?.getInt(CHAPTER_INDEX, 0) ?: 0
 
         metadataCompat.displayTitle = novel?.name ?: "Novel Name Not Found"
         metadataCompat.displaySubtitle = title

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/system/Activity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/system/Activity.kt
@@ -247,13 +247,14 @@ fun AppCompatActivity.startDownloadNovelService(novelName: String) {
     startService(serviceIntent)
 }
 
-fun AppCompatActivity.startTTSService(audioText: String, title: String, novelId: Long, sourceId: Long) {
+fun AppCompatActivity.startTTSService(audioText: String, title: String, novelId: Long, sourceId: Long, chapterIndex: Int = 0) {
     val serviceIntent = Intent(this, TTSService::class.java)
     val bundle = Bundle()
     bundle.putString(TTSService.AUDIO_TEXT_KEY, audioText)
     bundle.putString(TTSService.TITLE, title)
     bundle.putLong(TTSService.NOVEL_ID, novelId)
     bundle.putLong(TTSService.SOURCE_ID, sourceId)
+    bundle.putInt(TTSService.CHAPTER_INDEX, chapterIndex)
     serviceIntent.putExtras(bundle)
     startService(serviceIntent)
 }


### PR DESCRIPTION
When first (skipping) to the next chapter, TTS service will read the first one. Bug is now fixed.