### PR TITLE
Add option to show chapters left counter badge

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/GeneralSettingsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/settings/GeneralSettingsActivity.kt
@@ -29,6 +29,7 @@ class GeneralSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> 
         private const val POSITION_ENABLE_NOTIFICATIONS = 2
         private const val POSITION_LANGUAGES = 3
         private const val POSITION_ENABLE_SCROLLING_TEXT = 4
+        private const val POSITION_SHOW_CHAPTERS_LEFT_BADGE = 5
 
     }
 
@@ -106,6 +107,12 @@ class GeneralSettingsActivity : BaseActivity(), GenericAdapter.Listener<String> 
                 itemBinding.widgetSwitch.visibility = View.VISIBLE
                 itemBinding.widgetSwitch.isChecked = dataCenter.enableScrollingText
                 itemBinding.widgetSwitch.setOnCheckedChangeListener { _, value -> dataCenter.enableScrollingText = value }
+            }
+
+            POSITION_SHOW_CHAPTERS_LEFT_BADGE -> {
+                itemBinding.widgetSwitch.visibility = View.VISIBLE
+                itemBinding.widgetSwitch.isChecked = dataCenter.showChaptersLeftBadge
+                itemBinding.widgetSwitch.setOnCheckedChangeListener { _, isChecked -> dataCenter.showChaptersLeftBadge = isChecked }
             }
         }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/DataCenter.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/DataCenter.kt
@@ -62,6 +62,8 @@ class DataCenter(context: Context) {
         private const val DISABLE_WUXIA_DOWNLOADS = "disableWuxiaDownloads"
         private const val HAS_ALREADY_DELETED_OLD_CHANNELS = "hasAlreadyDeletedOldChannels"
         private const val LOGIN_COOKIES_STRING = "loginCookiesString"
+        private const val CUSTOM_QUERY_LOOKUPS = "customQueryLookups"
+        private const val SHOW_CHAPTERS_LEFT_BADGE = "showChaptersLeftBadge"
         private const val USER_SPECIFIED_SELECTOR_QUERIES = "userSpecifiedSelectorQueries"
 
         //Backup
@@ -268,6 +270,10 @@ class DataCenter(context: Context) {
         get() = prefs.getBoolean(HAS_ALREADY_DELETED_OLD_CHANNELS, false)
         set(value) = prefs.edit().putBoolean(HAS_ALREADY_DELETED_OLD_CHANNELS, value).apply()
 
+
+    var showChaptersLeftBadge: Boolean
+        get() = prefs.getBoolean(SHOW_CHAPTERS_LEFT_BADGE, false)
+        set(value) = prefs.edit().putBoolean(SHOW_CHAPTERS_LEFT_BADGE, value).apply()
 
     // Verified HostNames management
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -695,10 +695,10 @@
 
     <string name="source_not_installed">Source not installed: %1$s</string>
 
-    <string name="show_chapters_left_badge">Show chapters left badge</string>
+    <string name="show_chapters_left_badge">Show remaining chapters in badge</string>
     <string name="show_chapters_left_badge_description">
-        Instead of displaying a number of new chapters since the last time novel was read - badge will show the number of chapters left from the bookmark to the last chapter.
-        Badge color will be shown in red if there are new chapters since last time novel was read, otherwise color is dim.
+        Instead of showing the number of new chapters, show the chapters remaining based on the last chapter read.
+        The badge being red will still mean that there\'s a new chapter.
     </string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
         <item>@string/disable_notifications</item>
         <item>@string/change_language</item>
         <item>@string/scrolling_text</item>
+        <item>@string/show_chapters_left_badge</item>
     </string-array>
 
     <string-array name="general_subtitles_list" translatable="false">
@@ -120,6 +121,7 @@
         <item>@string/disable_notifications_description</item>
         <item>@string/locale_system_default</item>
         <item>@string/scrolling_text_description</item>
+        <item>@string/show_chapters_left_badge_description</item>
     </string-array>
 
     <string-array name="backup_and_restore_titles_list" translatable="false">
@@ -692,5 +694,11 @@
     <string name="information_webview_outdated">Please update the WebView app for better compatibility</string>
 
     <string name="source_not_installed">Source not installed: %1$s</string>
+
+    <string name="show_chapters_left_badge">Show chapters left badge</string>
+    <string name="show_chapters_left_badge_description">
+        Instead of displaying a number of new chapters since the last time novel was read - badge will show the number of chapters left from the bookmark to the last chapter.
+        Badge color will be shown in red if there are new chapters since last time novel was read, otherwise color is dim.
+    </string>
 
 </resources>


### PR DESCRIPTION
Adds an option to show a total counter from current bookmark to last chapter instead of vague "there's N new chapters since you last opened this novel". Badge still turns red if new chapters were added.

How it looks:
![img](https://media.discordapp.net/attachments/705088508301410305/826719818077044746/unknown.png?width=316&height=562)