### PR TITLE
Add origin language marker to novel browser.

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/RecentlyViewedNovelsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/RecentlyViewedNovelsActivity.kt
@@ -60,8 +60,8 @@ class RecentlyViewedNovelsActivity : BaseActivity(), GenericAdapter.Listener<Nov
         itemBinding.novelTitleTextView.text = item.name
         itemBinding.novelTitleTextView.isSelected = dataCenter.enableScrollingText
 
-        if (item.metadata.containsKey("Language")) {
-            itemBinding.novelLanguageText.text = item.metadata["Language"]
+        if (item.metadata.containsKey("OriginMarker")) {
+            itemBinding.novelLanguageText.text = item.metadata["OriginMarker"]
             itemBinding.novelLanguageText.visibility = View.VISIBLE
         }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/RecentlyViewedNovelsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/RecentlyViewedNovelsActivity.kt
@@ -60,6 +60,11 @@ class RecentlyViewedNovelsActivity : BaseActivity(), GenericAdapter.Listener<Nov
         itemBinding.novelTitleTextView.text = item.name
         itemBinding.novelTitleTextView.isSelected = dataCenter.enableScrollingText
 
+        if (item.metadata.containsKey("Language")) {
+            itemBinding.novelLanguageText.text = item.metadata["Language"]
+            itemBinding.novelLanguageText.visibility = View.VISIBLE
+        }
+
         if (item.rating != null) {
             var ratingText = "(N/A)"
             try {

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchTermFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchTermFragment.kt
@@ -181,6 +181,11 @@ class SearchTermFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Gener
         itemBinding.novelTitleTextView.text = item.name
         itemBinding.novelTitleTextView.isSelected = dataCenter.enableScrollingText
 
+        if (item.metadata.containsKey("Language")) {
+            itemBinding.novelLanguageText.text = item.metadata["Language"]
+            itemBinding.novelLanguageText.visibility = View.VISIBLE
+        }
+
         if (item.rating != null && item.rating != "N/A") {
             var ratingText = "(N/A)"
             try {

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchTermFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchTermFragment.kt
@@ -181,8 +181,8 @@ class SearchTermFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Gener
         itemBinding.novelTitleTextView.text = item.name
         itemBinding.novelTitleTextView.isSelected = dataCenter.enableScrollingText
 
-        if (item.metadata.containsKey("Language")) {
-            itemBinding.novelLanguageText.text = item.metadata["Language"]
+        if (item.metadata.containsKey("OriginMarker")) {
+            itemBinding.novelLanguageText.text = item.metadata["OriginMarker"]
             itemBinding.novelLanguageText.visibility = View.VISIBLE
         }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchUrlFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchUrlFragment.kt
@@ -164,6 +164,11 @@ class SearchUrlFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Generi
         itemBinding.novelTitleTextView.text = item.name
         itemBinding.novelTitleTextView.isSelected = dataCenter.enableScrollingText
 
+        if (item.metadata.containsKey("Language")) {
+            itemBinding.novelLanguageText.text = item.metadata["Language"]
+            itemBinding.novelLanguageText.visibility = View.VISIBLE
+        }
+
         if (item.rating != null) {
             var ratingText = "(N/A)"
             try {

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchUrlFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/SearchUrlFragment.kt
@@ -164,8 +164,8 @@ class SearchUrlFragment : BaseFragment(), GenericAdapter.Listener<Novel>, Generi
         itemBinding.novelTitleTextView.text = item.name
         itemBinding.novelTitleTextView.isSelected = dataCenter.enableScrollingText
 
-        if (item.metadata.containsKey("Language")) {
-            itemBinding.novelLanguageText.text = item.metadata["Language"]
+        if (item.metadata.containsKey("OriginMarker")) {
+            itemBinding.novelLanguageText.text = item.metadata["OriginMarker"]
             itemBinding.novelLanguageText.visibility = View.VISIBLE
         }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/source/NovelUpdatesSource.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/source/NovelUpdatesSource.kt
@@ -58,6 +58,8 @@ class NovelUpdatesSource : ParsedHttpSource() {
         val novel = Novel(url, id)
         element.selectFirst("div.search_title > a")?.text()?.let { novel.name = it }
         novel.imageUrl = element.selectFirst("div.search_img_nu img[src]")?.attr("abs:src")
+        val originText = element.select("div.search_ratings>span").text()
+        if (!originText.isNullOrEmpty()) novel.metadata["Language"] = originText
         val ratingText = element.select("div.search_ratings").text()
         if (ratingText.contains("(")) {
             novel.rating = ratingText.split("(")[1].trim().replace("(", "").replace(")", "")
@@ -270,6 +272,8 @@ class NovelUpdatesSource : ParsedHttpSource() {
         val novel = Novel(novelUrl, id)
         element.selectFirst("div.search_title > a")?.text()?.let { novel.name = it }
         novel.imageUrl = element.selectFirst("div.search_img_nu img[src]")?.attr("abs:src")
+        val originText = element.select("div.search_ratings>span").text()
+        if (!originText.isNullOrEmpty()) novel.metadata["Language"] = originText
         val ratingText = element.select("div.search_ratings").text()
         if (ratingText.contains("(")) {
             novel.rating = ratingText.split("(")[1].trim().replace("(", "").replace(")", "")

--- a/app/src/main/java/io/github/gmathi/novellibrary/source/NovelUpdatesSource.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/source/NovelUpdatesSource.kt
@@ -59,7 +59,7 @@ class NovelUpdatesSource : ParsedHttpSource() {
         element.selectFirst("div.search_title > a")?.text()?.let { novel.name = it }
         novel.imageUrl = element.selectFirst("div.search_img_nu img[src]")?.attr("abs:src")
         val originText = element.select("div.search_ratings>span").text()
-        if (!originText.isNullOrEmpty()) novel.metadata["Language"] = originText
+        if (!originText.isNullOrEmpty()) novel.metadata["OriginMarker"] = originText
         val ratingText = element.select("div.search_ratings").text()
         if (ratingText.contains("(")) {
             novel.rating = ratingText.split("(")[1].trim().replace("(", "").replace(")", "")
@@ -273,7 +273,7 @@ class NovelUpdatesSource : ParsedHttpSource() {
         element.selectFirst("div.search_title > a")?.text()?.let { novel.name = it }
         novel.imageUrl = element.selectFirst("div.search_img_nu img[src]")?.attr("abs:src")
         val originText = element.select("div.search_ratings>span").text()
-        if (!originText.isNullOrEmpty()) novel.metadata["Language"] = originText
+        if (!originText.isNullOrEmpty()) novel.metadata["OriginMarker"] = originText
         val ratingText = element.select("div.search_ratings").text()
         if (ratingText.contains("(")) {
             novel.rating = ratingText.split("(")[1].trim().replace("(", "").replace(")", "")

--- a/app/src/main/res/layout/listitem_novel.xml
+++ b/app/src/main/res/layout/listitem_novel.xml
@@ -66,6 +66,19 @@
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 
+                <TextView
+                    android:id="@+id/novelLanguageText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="2dp"
+                    android:layout_marginEnd="2dp"
+                    android:gravity="start|center_vertical"
+                    android:textIsSelectable="false"
+                    android:textSize="12sp"
+                    android:textStyle="italic"
+                    android:visibility="gone"
+                    tools:text="JP" />
+
                 <RatingBar
                     android:id="@+id/novelRatingBar"
                     style="@style/Widget.AppCompat.RatingBar.Small"


### PR DESCRIPTION
NU methods now parse the country of origin marker for novels (JP/KR/CN), and stores it in `OriginMarker` metadata. Then, if present, it is shown on the search panel. 
Other sources do not provide that metadata and hence do not display the marker.