### PR TITLE
Make Firebase queries additive to built-in queries

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/cleaner/HtmlCleaner.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/cleaner/HtmlCleaner.kt
@@ -191,8 +191,8 @@ open class HtmlCleaner protected constructor() {
 
         private fun getSelectorQueries(): List<SelectorQuery> {
             val dataCenter: DataCenter by injectLazy()
-            var htmlCleanerSelectorQueries = dataCenter.htmlCleanerSelectorQueries
-            if (htmlCleanerSelectorQueries.isNullOrEmpty()) htmlCleanerSelectorQueries = ArrayList(defaultSelectorQueries)
+            val htmlCleanerSelectorQueries = dataCenter.htmlCleanerSelectorQueries
+            htmlCleanerSelectorQueries.addAll(defaultSelectorQueries)
 
             val userSpecifiedSelectorQueries = dataCenter.userSpecifiedSelectorQueries
             if (userSpecifiedSelectorQueries.isNotBlank()) {


### PR DESCRIPTION
What the title says. Firebase queries won't override the selector list and instead would provide an additional list of them.
Current priority:
1. User-defined
2. Firebase
3. Built-in

User-defined queries will have to go at some point, as barely anyone uses it and either replaced by json-url user can supply or removed completely. 