### PR TITLE
Implement subquery processing commands

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/cleaner/GenericSelectorQueryCleaner.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/cleaner/GenericSelectorQueryCleaner.kt
@@ -144,7 +144,7 @@ class GenericSelectorQueryCleaner(
                 SubqueryProcessingCommand.AddId -> els.attr("id", value)
                 SubqueryProcessingCommand.AddClass -> value.split(",").forEach { els.addClass(it.trim()) }
                 SubqueryProcessingCommand.DisableTTS -> {
-                    els.attr("aria-hidden", "true")
+                    els.attr("tts-disable", "true")
                     if (value.isNotEmpty()) els.attr("tts-substitute", value)
                 }
                 SubqueryProcessingCommand.FilterNotRegex -> {

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/WebPageDBFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/WebPageDBFragment.kt
@@ -279,7 +279,7 @@ class WebPageDBFragment : BaseFragment() {
     }
 
     private fun loadCreatedDocument() {
-        doc?.body()?.append("<p><a aria-hidden=\"true\" href=\"abc://reset_page\">*** Go to top of page ***</a></p>")
+        doc?.body()?.append("<p><a tts-disable=\"true\" href=\"abc://reset_page\">*** Go to top of page ***</a></p>")
         webPageSettings.let {
             binding.readerWebView.loadDataWithBaseURL(
                 if (it.filePath != null) "$FILE_PROTOCOL${it.filePath}" else doc?.location(),

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/WebPageDBFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/WebPageDBFragment.kt
@@ -279,7 +279,7 @@ class WebPageDBFragment : BaseFragment() {
     }
 
     private fun loadCreatedDocument() {
-        doc?.body()?.append("<p><a href=\"abc://reset_page\">*** Go to top of page ***</a></p>")
+        doc?.body()?.append("<p><a aria-hidden=\"true\" href=\"abc://reset_page\">*** Go to top of page ***</a></p>")
         webPageSettings.let {
             binding.readerWebView.loadDataWithBaseURL(
                 if (it.filePath != null) "$FILE_PROTOCOL${it.filePath}" else doc?.location(),

--- a/app/src/main/java/io/github/gmathi/novellibrary/model/other/HtmlSelectorModels.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/model/other/HtmlSelectorModels.kt
@@ -25,5 +25,7 @@ data class SelectorQuery(val selector: String, val appendTitleHeader: Boolean = 
  */
 data class SelectorSubquery(val selector: String, val role: SubqueryRole,
                             val optional: Boolean = true, val multiple: Boolean = true,
-                            val extraProcessing: Map<SubqueryProcessingCommand, String> = emptyMap()
+                            val extraProcessing: List<SubqueryProcessingCommandInfo> = emptyList()
 )
+
+data class SubqueryProcessingCommandInfo(val command: SubqueryProcessingCommand, val value: String = "")

--- a/app/src/main/java/io/github/gmathi/novellibrary/model/other/HtmlSelectorModels.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/model/other/HtmlSelectorModels.kt
@@ -21,5 +21,9 @@ data class SelectorQuery(val selector: String, val appendTitleHeader: Boolean = 
  * @param role The subquery role. Depending on it, content is processed differently.
  * @param optional Allows query to be missing from the page. If mandatory query is not found, while SelectorQuery is discarded and not used for the website.
  * @param multiple Whether only first found query result is injected in reader mode or all of them.
+ * @param extraProcessing An optional list of extra processing commands for this subquery.
  */
-data class SelectorSubquery(val selector: String, val role: SubqueryRole, val optional: Boolean = true, val multiple: Boolean = true)
+data class SelectorSubquery(val selector: String, val role: SubqueryRole,
+                            val optional: Boolean = true, val multiple: Boolean = true,
+                            val extraProcessing: Map<SubqueryProcessingCommand, String> = emptyMap()
+)

--- a/app/src/main/java/io/github/gmathi/novellibrary/model/other/SubqueryProcessingCommand.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/model/other/SubqueryProcessingCommand.kt
@@ -1,0 +1,102 @@
+package io.github.gmathi.novellibrary.model.other
+
+@Suppress("KDocUnresolvedReference")
+enum class SubqueryProcessingCommand {
+    /**
+     * Unwraps the element contents top elements.
+     * Example use-case: Wattpad wrapping the contents into <pre> element, causing fonts to be monospace.
+     * @param commandArgument If not empty, will apply Wrap command with the tag name specified.
+     */
+    Unwrap,
+
+    /**
+     * Wraps tbe element with a new tag.
+     * @param commandArgument The name of the new tag.
+     */
+    Wrap,
+
+    /**
+     * Changes the element tag name to the one specified.
+     * @param commandArgument The new tag name of the element.
+     */
+    ChangeTag,
+
+    /**
+     * Adds specified classes to the element.
+     * @param commandArgument The comma-separated class list without dot.
+     */
+    AddClass,
+
+    /**
+     * Sets an ID for the element.
+     * @param commandArgument The new element ID.
+     */
+    AddId,
+
+    /**
+     * Adds an extra attribute to the element.
+     * @param commandArgument The attribute name and value separated by "=" equals sign.
+     */
+    AddAttribute,
+
+    /**
+     * Removes attributes from the element.
+     * @param commandArgument If not empty, removes only specified attribute names, otherwise removes all.
+     */
+    RemoveAttributes,
+
+    /**
+     * Remove all classes from the element.
+     * @param commandArgument If not empty, removes only specified classes, otherwise removes all.
+     */
+    RemoveClasses,
+
+    /**
+     * Remove the id attribute from the field.
+     * @param commandArgument If not empty, removes IDs only matching to the text, otherwise removes in any case.
+     */
+    RemoveId,
+
+    /**
+     * Filters the subquery search results and keeps only ones that do not contain specified string in the element text.
+     * Note that filter commands do not affect the pre-selection process of required subqueries.
+     * @param commandArgument The string that should be present in the text to discard element.
+     */
+    FilterNotString,
+
+    /**
+     * Filters the subquery search results and keeps only ones that do not match the specified regular expression in the element text.
+     * Note that filter commands do not affect the pre-selection process of required subqueries.
+     * @param commandArgument The regular expression that should match with the text to discard element.
+     */
+    FilterNotRegex,
+
+    /**
+     * Filters the subquery search results and keeps only ones that contain specified string in the element text.
+     * Note that filter commands do not affect the pre-selection process of required subqueries.
+     * @param commandArgument The string that should be present in the text in order to keep the element.
+     */
+    FilterOnlyString,
+
+    /**
+     * Filters the subquery search results and keeps only ones that match the specified regular expression in the element text.
+     * Note that filter commands do not affect the pre-selection process of required subqueries.
+     * @param commandArgument The regular expression that should match with text in order to keep the element.
+     */
+    FilterOnlyRegex,
+
+    /**
+     * Marks the elements as ones that should be avoid from being read by TTS.
+     * @param commandArgument If not empty, the element contents will be substituted by the argument text.
+     */
+    DisableTTS,
+
+    /**
+     * Marks the elements as one that contains the URL that leads outside of the buffer page if condition passes.
+     * Only applies to tags that contain `href` attribute.
+     * @param commandArgument
+     * TODO: Figure out how to do a condition with a string.
+     */
+    MarkBufferLink
+
+}

--- a/app/src/main/java/io/github/gmathi/novellibrary/model/other/SubqueryRole.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/model/other/SubqueryRole.kt
@@ -59,4 +59,9 @@ enum class SubqueryRole {
      * Do note that no cleanup is performed and IDs, classes and style are left intact.
      */
     RWhitelist,
+
+    /**
+     * Used only to execute processing commands and won't be removed nor added to the constructed contents.
+     */
+    RProcess,
 }


### PR DESCRIPTION
Expands the subquery capabilities with processing commands.
See SubqueryProcessingCommand for the list of supported commands atm.
I don't have an example of command usage for now, as wattpad (the one I wanted to test it on) is actually hiding chapter parts behind JS calls, rendering it unsuitable for fleshing the command system. But at the very least DisableTTS command can be useful. 

Other changes are:
* Added RProcess subquery role: Does nothing to the query results, but allows to execute some commands on those.
* Subquery elements now also append `data-role` with the subquery role value. This is added in order to improve TTS.
* Added `tts-disable="true"` to `*** Go to top of page ***` button appended by reader. Again, for TTS, because we don't want TTS to read it out.
