### PR TITLE
TTS Improvements

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -96,6 +96,12 @@
             android:label="@string/title_activity_novel_details"
             android:screenOrientation="fullUser"
             android:theme="@style/DarkTheme_DarkSide" />
+
+        <activity android:name=".activity.TextToSpeechControlsActivity"
+            android:label="@string/text_to_speech_controls"
+            android:screenOrientation="fullUser"
+            android:theme="@style/DarkTheme_DarkSide"
+            />
         <activity
             android:name=".activity.ImagePreviewActivity"
             android:label=""

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/ReaderDBPagerActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/ReaderDBPagerActivity.kt
@@ -383,6 +383,7 @@ class ReaderDBPagerActivity :
                         param(FAC.Param.NOVEL_NAME, novel.name)
                         param(FAC.Param.NOVEL_URL, novel.url)
                     }
+                    startTTSActivity()
                 } else {
                     showAlertDialog(title = "Read Aloud", message = "Only supported in Reader Mode!")
                 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/activity/TextToSpeechControlsActivity.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/activity/TextToSpeechControlsActivity.kt
@@ -1,0 +1,204 @@
+package io.github.gmathi.novellibrary.activity
+
+import android.content.ComponentName
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Bundle
+import android.os.IBinder
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import io.github.gmathi.novellibrary.R
+import io.github.gmathi.novellibrary.adapter.GenericAdapter
+import io.github.gmathi.novellibrary.database.getWebPage
+import io.github.gmathi.novellibrary.database.updateNovel
+import io.github.gmathi.novellibrary.databinding.ActivityTextToSpeechControlsBinding
+import io.github.gmathi.novellibrary.databinding.ContentTextToSpeechControlsBinding
+import io.github.gmathi.novellibrary.databinding.ListitemSentenceBinding
+import io.github.gmathi.novellibrary.extensions.isPlaying
+import io.github.gmathi.novellibrary.network.sync.NovelSync
+import io.github.gmathi.novellibrary.service.tts.TTSEventListener
+import io.github.gmathi.novellibrary.service.tts.TTSService
+import io.github.gmathi.novellibrary.util.lang.albumArt
+import io.github.gmathi.novellibrary.util.system.startReaderDBPagerActivity
+import io.github.gmathi.novellibrary.util.view.extensions.applyFont
+import io.github.gmathi.novellibrary.util.view.setDefaults
+
+class TextToSpeechControlsActivity : BaseActivity(), TTSEventListener, GenericAdapter.Listener<String> {
+    companion object {
+        const val TAG = "TextToSpeechControlsActivity"
+    }
+
+    lateinit var binding: ActivityTextToSpeechControlsBinding
+    lateinit var contentBinding: ContentTextToSpeechControlsBinding
+    var tts:TTSService? = null
+    var isServiceConnected = false
+
+    lateinit var adapter: GenericAdapter<String>
+    var lastSentence:Int = -1
+
+    private val ttsConnection = object : ServiceConnection {
+        override fun onServiceConnected(className: ComponentName?, service: IBinder?) {
+            val binder = service as TTSService.TTSBinder
+            tts = binder.getInstance()
+            tts?.eventListener = this@TextToSpeechControlsActivity
+            isServiceConnected = true
+            contentBinding.ttsInactiveOverlay.visibility = View.GONE
+            setRecycleView()
+            setPlaybackState()
+        }
+
+        override fun onServiceDisconnected(p0: ComponentName?) {
+            isServiceConnected = false
+            tts?.eventListener = null
+            contentBinding.ttsInactiveOverlay.visibility = View.VISIBLE
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityTextToSpeechControlsBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        contentBinding = binding.contentTextToSpeechControls
+
+        contentBinding.prevChapterButton.setOnClickListener {
+            if (isServiceConnected) tts?.chooseMediaControllerActions(TTSService.ACTION_PREVIOUS)
+        }
+        contentBinding.nextChapterButton.setOnClickListener {
+            if (isServiceConnected) tts?.chooseMediaControllerActions(TTSService.ACTION_NEXT)
+        }
+        contentBinding.prevSentenceButton.setOnClickListener {
+            if (isServiceConnected) tts?.chooseMediaControllerActions(TTSService.ACTION_PREV_SENTENCE)
+        }
+        contentBinding.nextSentenceButton.setOnClickListener {
+            if (isServiceConnected) tts?.chooseMediaControllerActions(TTSService.ACTION_NEXT_SENTENCE)
+        }
+        contentBinding.playButton.setOnClickListener {
+            if (isServiceConnected) tts?.chooseMediaControllerActions(
+                if (tts?.mediaController?.playbackState?.isPlaying == true) TTSService.ACTION_PAUSE
+                else TTSService.ACTION_PLAY
+            )
+        }
+        contentBinding.scrollIntoViewButton.setOnClickListener {
+            contentBinding.sentencesView.smoothScrollToPosition(lastSentence)
+        }
+
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+//        supportActionBar?.title = novel.name
+    }
+
+    private fun setRecycleView() {
+        if (tts == null || !isServiceConnected) return
+        val tts = this.tts!!
+        adapter = GenericAdapter(tts.lines, layoutResId = R.layout.listitem_sentence, listener = this)
+        lastSentence = tts.lineNumber
+        contentBinding.sentencesView.setDefaults(adapter)
+        contentBinding.sentencesView.scrollTo(0, 0)
+
+        tts.mediaController.metadata?.let { metadata ->
+            contentBinding.ttsNovelName.applyFont(assets).text = metadata.description.title
+            contentBinding.ttsNovelChapter.applyFont(assets).text = metadata.description.subtitle
+            contentBinding.ttsNovelCover.setImageBitmap(metadata.albumArt)
+        }
+        setProgress()
+    }
+
+    private fun setProgress() {
+        if (tts == null || !isServiceConnected) return
+        val tts = this.tts!!
+        contentBinding.chapterProgress.progress = tts.lineNumber
+        contentBinding.chapterProgress.max = tts.lines.count()
+    }
+
+    private fun setPlaybackState() {
+        if (tts?.mediaController?.playbackState?.isPlaying == true) {
+            contentBinding.playButton.let {
+                it.setImageDrawable(ContextCompat.getDrawable(this, R.drawable.ic_circle_pause_white))
+                it.contentDescription = getString(R.string.pause)
+            }
+        } else {
+            contentBinding.playButton.let {
+                it.setImageDrawable(ContextCompat.getDrawable(this, R.drawable.ic_circle_play_white))
+                it.contentDescription = getString(R.string.play)
+            }
+        }
+    }
+
+    override fun bind(item: String, itemView: View, position: Int) {
+        val binding = ListitemSentenceBinding.bind(itemView)
+        binding.sentenceContents.applyFont(assets).text = item
+        binding.sentenceLayout.setBackgroundColor(ContextCompat.getColor(this,
+            if (lastSentence == position) R.color.colorLightBlue
+            else android.R.color.transparent
+        ))
+    }
+
+    override fun onItemClick(item: String, position: Int) {
+        if (isServiceConnected) {
+            tts?.goToLine(position)
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        Intent(this, TTSService::class.java).also { intent ->
+            bindService(intent, ttsConnection, 0)
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        unbindService(ttsConnection)
+        tts?.eventListener = null
+        isServiceConnected = false
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.menu_text_to_speech, menu)
+        return super.onCreateOptionsMenu(menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when(item.itemId) {
+            android.R.id.home -> finish()
+            R.id.action_open_reader -> {
+                finishAfterTransition()
+                if (isServiceConnected) tts?.let { tts ->
+                    tts.novel?.let { novel ->
+                        dbHelper.getWebPage(novel.id, tts.translatorSourceName, tts.chapterIndex)?.let { chapter ->
+                            novel.currentChapterUrl = chapter.url
+                            dbHelper.updateNovel(novel)
+                            NovelSync.getInstance(novel)?.applyAsync(lifecycleScope) { if (dataCenter.getSyncBookmarks(it.host)) it.setBookmark(novel, chapter) }
+                            startReaderDBPagerActivity(novel, tts.translatorSourceName)
+                        }
+                    }
+                }
+
+            }
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    override fun onReadingStart() {
+        setRecycleView()
+    }
+
+    override fun onReadingStop() {
+    }
+
+    override fun onSentenceChange(sentenceIndex: Int) {
+        adapter.notifyItemChanged(lastSentence)
+        lastSentence = sentenceIndex
+        adapter.notifyItemChanged(sentenceIndex)
+        contentBinding.sentencesView.invalidate()
+        setProgress()
+    }
+
+    override fun onPlaybackStateChange() {
+        setPlaybackState()
+    }
+
+}

--- a/app/src/main/java/io/github/gmathi/novellibrary/service/tts/TTSEventListener.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/service/tts/TTSEventListener.kt
@@ -1,0 +1,9 @@
+package io.github.gmathi.novellibrary.service.tts
+
+interface TTSEventListener {
+    fun onReadingStart()
+    fun onSentenceChange(sentenceIndex:Int)
+    fun onReadingStop()
+    fun onPlaybackStateChange()
+
+}

--- a/app/src/main/java/io/github/gmathi/novellibrary/service/tts/TTSNotificationBuilder.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/service/tts/TTSNotificationBuilder.kt
@@ -25,6 +25,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.os.Build
 import android.support.v4.media.session.MediaControllerCompat
 import android.support.v4.media.session.MediaSessionCompat
+import android.widget.RemoteViews
 import androidx.annotation.RequiresApi
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.app.NotificationCompat
@@ -67,6 +68,11 @@ class TTSNotificationBuilder(private val context: Context, pendingIntents: HashM
         context.getString(R.string.next_chapter),
         pendingIntents[TTSService.ACTION_NEXT]
     )
+    private val openControlsAction = NotificationCompat.Action(
+        R.drawable.ic_open_in_browser_white_vector,
+        context.getString(R.string.text_to_speech_controls),
+        pendingIntents[TTSService.ACTION_OPEN_CONTROLS]
+    )
     private val stopPendingIntent =
         pendingIntents[TTSService.ACTION_STOP]
 
@@ -88,6 +94,7 @@ class TTSNotificationBuilder(private val context: Context, pendingIntents: HashM
             builder.addAction(playAction)
         }
         builder.addAction(skipToNextAction)
+        builder.addAction(openControlsAction)
 
         val drawable = AppCompatResources.getDrawable(context, R.mipmap.ic_launcher)
         if (drawable is BitmapDrawable) {
@@ -95,20 +102,30 @@ class TTSNotificationBuilder(private val context: Context, pendingIntents: HashM
         }
 
 
-        val mediaStyle = androidx.media.app.NotificationCompat.MediaStyle()
+        val mediaStyle = androidx.media.app.NotificationCompat.DecoratedMediaCustomViewStyle()
             .setCancelButtonIntent(stopPendingIntent)
             .setMediaSession(sessionToken)
             .setShowActionsInCompactView(1)
             .setShowCancelButton(true)
+        val smallView = RemoteViews("io.github.gmathi.novellibrary", R.layout.notification_tts)
+        smallView.setTextViewText(R.id.notificationTitle, description.title)
+        smallView.setTextViewText(R.id.notificationDescription, description.subtitle)
+
+        val bigView = RemoteViews("io.github.gmathi.novellibrary", R.layout.notification_tts_large)
+        bigView.setTextViewText(R.id.notificationTitle, description.title)
+        bigView.setTextViewText(R.id.notificationDescription, description.subtitle)
 
         return builder.setContentIntent(controller.sessionActivity)
-            .setContentText(description.subtitle)
-            .setContentTitle(description.title)
-            .setDeleteIntent(stopPendingIntent)
-            .setLargeIcon(description.iconBitmap)
-            .setOnlyAlertOnce(true)
-            .setSmallIcon(R.drawable.ic_queue_music_white_vector)
             .setStyle(mediaStyle)
+            .setLargeIcon(description.iconBitmap)
+            .setSmallIcon(R.drawable.ic_queue_music_white_vector)
+            .setCustomContentView(smallView)
+            .setCustomBigContentView(bigView)
+//            .setContentText(description.subtitle)
+//            .setContentTitle(description.title)
+            .setDeleteIntent(stopPendingIntent)
+            .setOnlyAlertOnce(true)
+            .setColorized(true)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .build()
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/system/ActivityExt.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/system/ActivityExt.kt
@@ -82,6 +82,16 @@ fun AppCompatActivity.startReaderDBPagerActivity(novel: Novel) {
     startActivityForResult(intent, Constants.READER_ACT_REQ_CODE)
 }
 
+fun AppCompatActivity.startReaderDBPagerActivity(novel: Novel, translatorSourceName: String?) {
+    val intent = Intent(this, ReaderDBPagerActivity::class.java)
+    val bundle = Bundle()
+    bundle.putParcelable("novel", novel)
+    if (translatorSourceName != null)
+        bundle.putString("translatorSourceName", translatorSourceName)
+    intent.putExtras(bundle)
+    startActivityForResult(intent, Constants.READER_ACT_REQ_CODE)
+}
+
 
 fun AppCompatActivity.startSearchResultsActivity(title: String, url: String) {
     val intent = Intent(this, SearchUrlActivity::class.java)
@@ -260,6 +270,10 @@ fun AppCompatActivity.startTTSService(audioText: String, title: String, novelId:
     bundle.putInt(TTSService.CHAPTER_INDEX, chapterIndex)
     serviceIntent.putExtras(bundle)
     startService(serviceIntent)
+}
+
+fun AppCompatActivity.startTTSActivity() {
+    startActivity(Intent(this, TextToSpeechControlsActivity::class.java))
 }
 
 fun Activity.showAlertDialog(title: String? = null, message: String? = null, @DrawableRes icon: Int = R.drawable.ic_warning_white_vector) {

--- a/app/src/main/res/drawable/ic_fast_forward_white.xml
+++ b/app/src/main/res/drawable/ic_fast_forward_white.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    >
+    <path
+        android:fillColor="#ffffffff"
+        android:pathData="M4 18l8.5-6L4 6v12zm9-12v12l8.5-6L13 6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_fast_rewind_white.xml
+++ b/app/src/main/res/drawable/ic_fast_rewind_white.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    >
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M11 18V6l-8.5 6 8.5 6zm.5-6l8.5 6V6l-8.5 6z"/>
+</vector>

--- a/app/src/main/res/layout/activity_text_to_speech_controls.xml
+++ b/app/src/main/res/layout/activity_text_to_speech_controls.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/AppTheme.PopupOverlay" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <include
+        android:id="@+id/contentTextToSpeechControls"
+        layout="@layout/content_text_to_speech_controls" />
+
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_text_to_speech_controls.xml
+++ b/app/src/main/res/layout/content_text_to_speech_controls.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/sentencesView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/controlsLayout"
+        android:layout_alignParentTop="true"
+        android:layout_marginTop="0dp"
+        android:layout_marginBottom="0dp"
+        android:overScrollMode="always"
+        android:scrollbars="vertical"
+        tools:itemCount="60"
+        tools:listitem="@layout/listitem_sentence" />
+
+    <LinearLayout
+        android:id="@+id/controlsLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_marginBottom="10dp"
+        android:gravity="bottom"
+        android:orientation="vertical">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <ImageView
+                android:id="@+id/ttsNovelCover"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentTop="true"
+                android:layout_marginStart="5dp"
+                android:layout_marginTop="0dp"
+                android:layout_marginBottom="0dp"
+                app:srcCompat="@drawable/ic_art_track_white_vector" />
+
+            <TextView
+                android:id="@+id/ttsNovelName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentEnd="true"
+                android:layout_marginStart="2dp"
+                android:layout_marginTop="2dp"
+                android:layout_marginEnd="5dp"
+                android:layout_toEndOf="@id/ttsNovelCover"
+                android:ellipsize="marquee"
+                android:fadingEdge="horizontal"
+                android:marqueeRepeatLimit="marquee_forever"
+                android:scrollHorizontally="true"
+                android:singleLine="true"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                tools:text="Novel Name - a very one long at that causing it ellipsize so hard it would fire outside of the editor" />
+
+            <TextView
+                android:id="@+id/ttsNovelChapter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/ttsNovelName"
+                android:layout_alignParentEnd="true"
+                android:layout_marginStart="2dp"
+                android:layout_marginTop="2dp"
+                android:layout_marginEnd="5dp"
+                android:layout_toEndOf="@+id/ttsNovelCover"
+                android:ellipsize="marquee"
+                android:fadingEdge="horizontal"
+                android:marqueeRepeatLimit="marquee_forever"
+                android:scrollHorizontally="true"
+                android:singleLine="true"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                tools:text="Novel chapter" />
+        </RelativeLayout>
+
+        <ProgressBar
+            android:id="@+id/chapterProgress"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:max="100"
+            android:progress="50"
+            android:progressTint="@color/colorStateBlue" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:orientation="horizontal">
+
+            <Space
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <ImageView
+                android:id="@+id/prevChapterButton"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:contentDescription="@string/previous_chapter"
+                app:srcCompat="@drawable/ic_skip_previous_white" />
+
+            <Space
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <ImageView
+                android:id="@+id/prevSentenceButton"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:contentDescription="@string/previous_sentence"
+                app:srcCompat="@drawable/ic_fast_rewind_white" />
+
+            <Space
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <ImageView
+                android:id="@+id/playButton"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:contentDescription="@string/play"
+                app:srcCompat="@drawable/ic_circle_play_white" />
+
+            <Space
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <ImageView
+                android:id="@+id/nextSentenceButton"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:contentDescription="@string/next_sentence"
+                app:srcCompat="@drawable/ic_fast_forward_white" />
+
+            <Space
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <ImageView
+                android:id="@+id/nextChapterButton"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:contentDescription="@string/next_chapter"
+                app:srcCompat="@drawable/ic_skip_next_white" />
+
+            <Space
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/ttsInactiveOverlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:drawable/screen_background_dark_transparent"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:padding="?attr/dialogPreferredPadding"
+        tools:visibility="gone">
+
+        <ImageView
+            android:layout_width="86dp"
+            android:layout_height="86dp"
+            app:srcCompat="@drawable/ic_queue_music_white_vector" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/text_to_speech_inactive"
+            android:textAlignment="center"
+            android:textSize="24sp" />
+    </LinearLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/scrollIntoViewButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignBottom="@+id/sentencesView"
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="12dp"
+        android:layout_marginBottom="12dp"
+        android:clickable="true"
+        app:srcCompat="@drawable/ic_forward_white_vector" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/listitem_sentence.xml
+++ b/app/src/main/res/layout/listitem_sentence.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/sentenceLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="8dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="8dp"
+    android:paddingBottom="4dp">
+
+    <TextView
+        android:id="@+id/sentenceContents"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="3dp"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="16sp"
+        tools:text=" Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a urna vitae lectus ultrices mattis. Ut congue purus et lectus sagittis, at blandit turpis vehicula. Pellentesque pulvinar libero luctus metus." />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@android:color/darker_gray" />
+</LinearLayout>

--- a/app/src/main/res/layout/notification_tts.xml
+++ b/app/src/main/res/layout/notification_tts.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/notificationTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:marqueeRepeatLimit="marquee_forever"
+        android:ellipsize="marquee"
+        android:singleLine="true"
+        android:scrollHorizontally="true"
+        android:fadingEdge="horizontal"
+        android:textAppearance="@style/TextAppearance.Compat.Notification.Title.Media"
+        tools:text="Notification Title" />
+
+    <TextView
+        android:id="@+id/notificationDescription"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:marqueeRepeatLimit="marquee_forever"
+        android:ellipsize="marquee"
+        android:singleLine="true"
+        android:scrollHorizontally="true"
+        android:fadingEdge="horizontal"
+        android:textAppearance="@style/TextAppearance.Compat.Notification.Media"
+        tools:text="Notification Description" />
+</LinearLayout>

--- a/app/src/main/res/layout/notification_tts_large.xml
+++ b/app/src/main/res/layout/notification_tts_large.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/notificationTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.Compat.Notification.Title.Media"
+        tools:text="Notification Title" />
+
+    <TextView
+        android:id="@+id/notificationDescription"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.Compat.Notification.Media"
+        tools:text="Notification Description" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/switch_item.xml
+++ b/app/src/main/res/layout/switch_item.xml
@@ -1,0 +1,11 @@
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Switch
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true" />
+</RelativeLayout>

--- a/app/src/main/res/menu/menu_text_to_speech.xml
+++ b/app/src/main/res/menu/menu_text_to_speech.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/action_open_reader"
+        android:icon="@drawable/ic_chrome_reader_mode_white_vector"
+        android:title="@string/open_reader"
+        android:titleCondensed="@string/open_reader"
+        app:showAsAction="ifRoom|withText" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -558,6 +558,11 @@
     <string name="previous_chapter">Previous Chapter</string>
     <string name="next_chapter">Next Chapter</string>
     <string name="connection_error">Connection Error!</string>
+    <string name="next_sentence">Next sentence</string>
+    <string name="previous_sentence">Previous sentence</string>
+    <string name="text_to_speech_controls">TTS Controls</string>
+    <string name="text_to_speech_inactive">TTS Service is not active.\nStart the TTS playback trough the chapter view first!</string>
+    <string name="open_reader">Open reader</string>
 
     <!-- v0.9 Strings -->
 


### PR DESCRIPTION
* Added TTS Controls activity
Now when user clicks on TTS button, apart from launching TTS service - the controls activity will be open. 
Features are: 
  * Jump chapters
  * Jump next/previous sentence (or rather a group of sentences/text chunk).
  * Play/Pause
  * Jump specific sentence by clicking on it in the view
  * Open currently read out chapter in the reader
* Extended notification no longer clip novel/chapter name. It does make it bigger vertically, but I think being able to actually see what chapter it currently reads out worth it.
* TTS line splitting routine:
  * Redone the logic to respect the actual TTS character limit, but cap it at 500 characters regardless.
  * Sentence endings are now detected not only via dots, but also other special characters. It still can be improved, to avoid splits at `some sentence (with correction)^ that has parenthesis in it.`
* TTS-specific cleaner (`Document.getFormattedText()`) routine:
  * Instead of grabbing entire page, only RContent part is used. No header/footer/comments/etc. Depends on #202
  * Fixed `&nbsp;` causing "semicolon" spam in TTS due to replacement not including the `;`
  * Added space trimmer: Many spaces now get reduced to just one.
  * Added character repeat reducer: Spam of special characters such as `####` would get reduced to just 3 characters. Also reduces `!!!!!!` punctuation spam.
  * Fix the chapter title readout repeat. Depends on #202 and will only work on comprehensive queries or when chapter title does not get injected into RContent part.

This should make TTS capabilities of the app get a lot better. But there's still room for improvement!

## What can be improved still
* On top of passing just text, also extract the potential chapter page and buffer links to make them available to TTS
  * Present those as "Read next" and "Replace with" buttons so TTS can read content after buffer page or next page instead of jumping next chapter without reading actual chapter.
  * Add an option to "Merge pages in TTS", since currently buffer pages are TTS nemesis.
* We can still work on cleanup routines. For example, swap inline url text with something like "url link". Because listening for half a minute for TTS to struggle with "ash ti ti pi es colon slash slash somewebsite dot com slash very long url slash? some meta equals percent twenty etc"
* Add the media events handling: Actually pause if uses presses "Play" button on their accessory. Also handle prev/next with option to either it being "Jump sentence" or "Jump chapter".
* Add option to mark chapters as read and move bookmarks along with TTS.
* Very far in the future: Add SSML formatting mode. I don't think it's worth it, but hey, some TTS engines support it.
* Questionable: Add option to "pre-record" chapter into file for later listening. 

My next goal is likely to do some refactoring on a whole.