### PR TITLE
Grab CF cookies from non-reader mode.

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/network/HostNames.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/network/HostNames.kt
@@ -1,6 +1,7 @@
 package io.github.gmathi.novellibrary.network
 
 
+import io.github.gmathi.novellibrary.model.source.online.HttpSource
 import java.util.*
 
 object HostNames {
@@ -28,7 +29,7 @@ object HostNames {
     const val CHRYSANTHEMUMGARDEN = "chrysanthemumgarden.com"
     const val VOLARE_NOVELS = "volarenovels.com"
 
-    const val USER_AGENT = "Mozilla/5.0 (Linux; Android 5.1.1; Nexus 6 Build/LYZ28E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.84 Mobile Safari/537.36"
+    const val USER_AGENT = HttpSource.DEFAULT_USER_AGENT//"Mozilla/5.0 (Linux; Android 5.1.1; Nexus 6 Build/LYZ28E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.84 Mobile Safari/537.36"
 
     private val DEFAULT_ALLOWED_HOST_NAMES_ARRAY = arrayOf(
         NOVEL_UPDATES,


### PR DESCRIPTION
Now if NU or destination site cannot be bypassed automatically, user can switch to non-reader, pass the check and return to reader mode.
Changed `HostNames.USER_AGENT` to be aliased to `HttpSource.DEFAULT_USER_AGENT` since it was causing cf clearance incompatibility.

We probably would need to return "Check cloudflare" menu at some point if automatic CF avoidance isn't implemented.