### PR TITLE
Add release frequency to novel metadata (NU)

### DIFF
--- a/app/src/main/java/io/github/gmathi/novellibrary/source/NovelUpdatesSource.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/source/NovelUpdatesSource.kt
@@ -21,6 +21,7 @@ import io.github.gmathi.novellibrary.util.network.asJsoup
 import okhttp3.*
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import org.jsoup.nodes.TextNode
 import rx.Observable
 import rx.schedulers.Schedulers
 import java.net.URLEncoder
@@ -100,6 +101,9 @@ class NovelUpdatesSource : ParsedHttpSource() {
         document.select("#mypostid")?.firstOrNull()?.attr("value")?.let {
             novel.externalNovelId = it
             novel.metadata["PostId"] = it
+        }
+        document.select("h5.seriesother").firstOrNull { el -> el.ownText() == "Release Frequency" }?.nextSibling()?.let { node ->
+            if (node is TextNode) novel.metadata["Release Frequency"] = node.text().trim()
         }
 
         return novel


### PR DESCRIPTION
What the title says. Now it's possible to see release frequency on NU novels metadata.
Request: https://discord.com/channels/339610451711361024/339611455013781506/859091957825536070