### PR TITLE
Add support for post-load proxy handling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -219,6 +219,9 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics-ktx'
 
     implementation 'com.zhkrb.cloudflare-scrape-android:scrape-webview:0.0.4'
+
+    // Markdown parser for websites that use markdown
+    implementation "org.jetbrains:markdown:0.3.1"
 }
 
 task countTranslations {

--- a/app/src/main/java/io/github/gmathi/novellibrary/cleaner/GenericSelectorQueryCleaner.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/cleaner/GenericSelectorQueryCleaner.kt
@@ -14,11 +14,14 @@ class GenericSelectorQueryCleaner(
 
     companion object {
         val DIRECTIONAL_LINKS = listOf(
-            "Previous Chapter", "Next Chapter", "[Previous Chapter]", "[Next Chapter]",
-            "Previous", "Next", "[Previous]", "[Next]",
-            "Project Page",
-            "Index", "Table of Contents", "TOC", "[Index]", "[Table of Contents]", "[TOC]"
+//            "Previous Chapter", "Next Chapter", "[Previous Chapter]", "[Next Chapter]", "Prev", "[Prev]",
+//            "Previous", "Next", "[Previous]", "[Next]",
+            "Project Page", "Glossary",
+//            "Index", "Table of Contents", "TOC", "[Index]", "[Table of Contents]", "[TOC]"
         )
+        val PREV_REGEX = Regex("""^\s*\W*\s*Prev(?:ious)?(?:\sChapter)?$""", RegexOption.IGNORE_CASE)
+        val NEXT_REGEX = Regex("""^\s*\W*\s*Next(?:\sChapter)?\s*\W*\s*$""", RegexOption.IGNORE_CASE)
+        val TOC_REGEX = Regex("""^\s*\W*\s*(Index|TOC|Table of Contents)(\s*\W*\s*|\s\W\s.+)$""", RegexOption.IGNORE_CASE)
     }
 
     override fun additionalProcessing(doc: Document) {
@@ -54,7 +57,7 @@ class GenericSelectorQueryCleaner(
              * Comprehensive SubQueries
              */
 
-            val subContent = subQueries.map { if (it.selector.isEmpty()) Elements() else body.select(it.selector) }
+            val subContent = subQueries.map { it.select(body) }
             removeCSS(doc)
             subContent.forEachIndexed { index, elements ->
                 val subQuery = subQueries[index]
@@ -230,14 +233,14 @@ class GenericSelectorQueryCleaner(
 
     override fun getLinkedChapters(doc: Document): ArrayList<LinkedPage> {
         if (query.subQueries.isNotEmpty()) {
-            return getLinkedChapters(doc.location(), doc.body().select(query.subQueries.first { it.role == SubqueryRole.RContent }.selector).firstOrNull())
+            return getLinkedChapters(doc.location(), query.subQueries.first { it.role == SubqueryRole.RContent }.select(doc.body()).firstOrNull())
         }
         return getLinkedChapters(doc.location(), doc.body().select(query.selector).firstOrNull())
     }
 
     private fun isDirectionalLink(el: Element): Boolean {
         val text = el.text()
-        return DIRECTIONAL_LINKS.any { text.equals(it, ignoreCase = true) }
+        return text.matches(NEXT_REGEX) || text.matches(PREV_REGEX) || text.matches(TOC_REGEX) || DIRECTIONAL_LINKS.any { text.equals(it, ignoreCase = true) }
     }
 
     private fun markDirectionalLinks(contentElement: Elements) {

--- a/app/src/main/java/io/github/gmathi/novellibrary/model/other/HtmlSelectorModels.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/model/other/HtmlSelectorModels.kt
@@ -1,5 +1,9 @@
 package io.github.gmathi.novellibrary.model.other
 
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import org.jsoup.select.Elements
+
 /**
  * @param selector The CSS selector used to find the content unless Content subQuery is used.
  * @param appendTitleHeader Whether to append the document title to the cleaned up page unless Header is present and found.
@@ -22,10 +26,18 @@ data class SelectorQuery(val selector: String, val appendTitleHeader: Boolean = 
  * @param optional Allows query to be missing from the page. If mandatory query is not found, while SelectorQuery is discarded and not used for the website.
  * @param multiple Whether only first found query result is injected in reader mode or all of them.
  * @param extraProcessing An optional list of extra processing commands for this subQuery.
+ * @param customSelector Built-in selector exclusive callback to select the contents of the sub-query.
+ * For websites that don't have easily distinctive elements and need some custom selector implementation.
  */
 data class SelectorSubQuery(val selector: String, val role: SubqueryRole,
                             val optional: Boolean = true, val multiple: Boolean = true,
-                            val extraProcessing: List<SubQueryProcessingCommandInfo> = emptyList()
+                            val extraProcessing: List<SubQueryProcessingCommandInfo> = emptyList(),
+                            val customSelector: ((doc: Element) -> Elements)? = null,
 )
+
+fun SelectorSubQuery.select(doc: Element): Elements {
+    return customSelector?.invoke(doc) ?: if (selector.isEmpty()) Elements()
+    else doc.select(selector)
+}
 
 data class SubQueryProcessingCommandInfo(val command: SubQueryProcessingCommand, val value: String = "")

--- a/app/src/main/java/io/github/gmathi/novellibrary/network/postProxy/BasePostProxyHelper.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/network/postProxy/BasePostProxyHelper.kt
@@ -1,0 +1,70 @@
+package io.github.gmathi.novellibrary.network.postProxy
+
+import androidx.core.text.htmlEncode
+import com.github.salomonbrys.kotson.fromJson
+import com.google.gson.Gson
+import io.github.gmathi.novellibrary.network.NetworkHelper
+import io.github.gmathi.novellibrary.network.WebPageDocumentFetcher
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
+import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.parser.MarkdownParser
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import uy.kohesive.injekt.injectLazy
+
+/**
+ * @see io.github.gmathi.novellibrary.network.NovelApi.getDocumentWithParams
+ */
+open class BasePostProxyHelper {
+
+    val networkHelper: NetworkHelper by injectLazy()
+    val client: OkHttpClient
+        get() = networkHelper.cloudflareClient
+
+    companion object {
+        fun getInstance(response: Response): BasePostProxyHelper? {
+            val url = response.request.url.toString()
+            return when {
+                url.contains("inoveltranslation.com") -> object : JsonContentProxy<INovelTranslationJson>() {
+                    override fun extractJson(doc: Document): Document? {
+                        """/chapters/(\d+)""".toRegex().find(doc.location())?.let { match ->
+                            val jsonString = string(connect(request("https://api.inoveltranslation.com/chapters/${match.groups[1]!!.value}"))) ?: return null
+                            val json: INovelTranslationJson = Gson().fromJson(jsonString)
+                            val html = json.content.let {
+                                val flavour = CommonMarkFlavourDescriptor()
+                                val tree = MarkdownParser(flavour).buildMarkdownTreeFromString(it)
+                                HtmlGenerator(it, tree, flavour).generateHtml()
+                            }
+                            return Jsoup.parse("""
+                            <!DOCTYPE html>
+                            <html>
+                                <head>
+                                    <title>${json.novel.title} -${json.volume?.let { " vol.$it" } ?: ""} ch.${json.chapter}${json.title?.let { " - ${it.htmlEncode()}" } ?: ""}</title>
+                                </head>
+                                <body>
+                                    <div class="content">$html</div>
+                                </body>
+                            </html>
+                            """.trimIndent(), doc.location()
+                            )
+                        }
+                        return null
+                    }
+                }
+                else -> null
+            }
+        }
+    }
+
+    /** Connection used when requesting document. */
+    open fun request(url: String): Request = WebPageDocumentFetcher.request(url)
+    open fun connect(request: Request): Response = WebPageDocumentFetcher.connect(request)
+    open fun document(response: Response): Document = WebPageDocumentFetcher.document(response)
+    open fun string(response: Response): String? = WebPageDocumentFetcher.string(response)
+}
+
+private data class INovelTranslationJson(val chapter: Int, val content: String, val id: Int, val tier: Any?, val tierId: Any?, val title: String?, val volume: Int?, val novel: INovelTranslationJsonNovel)
+private data class INovelTranslationJsonNovel(val cover: Any?, val id: Int, val patreon: Any?, val title: String)

--- a/app/src/main/java/io/github/gmathi/novellibrary/network/postProxy/BasePostProxyHelper.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/network/postProxy/BasePostProxyHelper.kt
@@ -35,7 +35,7 @@ open class BasePostProxyHelper {
                             val json: INovelTranslationJson = Gson().fromJson(jsonString)
                             val raw = json.content
                                 // Hide obnoxious T/N notes in TTS.
-                                .replace("""---\s*T/N:.+(\n\[?!$|---)""".toRegex(setOf(RegexOption.DOT_MATCHES_ALL)), "<div tts-disable=\"true\">\n\n$0\n\n</div>")
+                                .replace("""---\s*(T/N:|Hello!\s?\?\?+).+(\n\[!$|---)""".toRegex(setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.MULTILINE)), "<div tts-disable=\"true\">\n\n$0\n\n</div>")
                                 .replace("""T/N:.+shoutout to the following:.*?for being.*?patre?ons?.*?$""".toRegex(setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.MULTILINE)), "<div tts-disable=\"true\">\n\n$0\n\n</div>")
                                 .replace("""(Editor|Translator|T/N): .+""".toRegex(), "<p tts-disable=\"true\">$0</p>")
                             val html = raw.let {

--- a/app/src/main/java/io/github/gmathi/novellibrary/network/postProxy/JsonContentProxy.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/network/postProxy/JsonContentProxy.kt
@@ -1,0 +1,17 @@
+package io.github.gmathi.novellibrary.network.postProxy
+
+import io.github.gmathi.novellibrary.network.proxy.BaseProxyHelper
+import io.github.gmathi.novellibrary.util.network.asJsoup
+import okhttp3.Response
+import org.jsoup.nodes.Document
+
+abstract class JsonContentProxy<T> : BasePostProxyHelper() {
+    abstract fun extractJson(doc: Document): Document?
+
+    override fun document(response: Response): Document {
+        val doc = response.asJsoup()
+        val jdoc = extractJson(doc)
+        return extractJson(doc) ?: doc
+    }
+
+}

--- a/app/src/main/java/io/github/gmathi/novellibrary/network/proxy/BaseProxyHelper.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/network/proxy/BaseProxyHelper.kt
@@ -1,8 +1,12 @@
 package io.github.gmathi.novellibrary.network.proxy
 
+import androidx.core.text.htmlEncode
+import com.github.salomonbrys.kotson.fromJson
+import com.google.gson.Gson
 import io.github.gmathi.novellibrary.network.HostNames
 import io.github.gmathi.novellibrary.network.NetworkHelper
 import io.github.gmathi.novellibrary.network.WebPageDocumentFetcher
+import io.github.gmathi.novellibrary.network.postProxy.JsonContentProxy
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -31,5 +35,5 @@ open class BaseProxyHelper {
     open fun request(url: String): Request = WebPageDocumentFetcher.request(url)
     open fun connect(request: Request): Response = WebPageDocumentFetcher.connect(request)
     open fun document(response: Response): Document = WebPageDocumentFetcher.document(response)
-    //open fun string(response: Response): String? = WebPageDocumentFetcher.string(response)
+    open fun string(response: Response): String? = WebPageDocumentFetcher.string(response)
 }

--- a/app/src/main/java/io/github/gmathi/novellibrary/service/tts/TTSPlayer.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/service/tts/TTSPlayer.kt
@@ -35,6 +35,7 @@ import io.github.gmathi.novellibrary.network.NetworkHelper
 import io.github.gmathi.novellibrary.util.Constants
 import io.github.gmathi.novellibrary.util.Constants.FILE_PROTOCOL
 import io.github.gmathi.novellibrary.model.preference.DataCenter
+import io.github.gmathi.novellibrary.network.WebPageDocumentFetcher
 import io.github.gmathi.novellibrary.util.Utils.getFormattedText
 import io.github.gmathi.novellibrary.util.getLinkedPagesCompat
 import io.github.gmathi.novellibrary.util.lang.*
@@ -603,13 +604,8 @@ class TTSPlayer(private val context: Context,
         chapterCache.add(clean)
     }
 
-    private suspend fun getWebPageDocument(url: String): Document {
-        val doc = client.newCall(GET(url)).safeExecute().asJsoup()
-        // Clearly a crutch that should not be there?
-        if (doc.location().contains("rssbook") && doc.location().contains(HostNames.QIDIAN)) {
-            return withIOContext { getWebPageDocument(doc.location().replace("rssbook", "book")) }
-        }
-        return doc
+    private fun getWebPageDocument(url: String): Document {
+        return WebPageDocumentFetcher.document(url)
     }
 
     private fun cleanDocumentText(doc: Document, index: Int): TTSCleanDocument {

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/Utils.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/Utils.kt
@@ -408,7 +408,6 @@ object Utils {
         doc.select("br,p,hr").forEach {
             it.after("\n")
         }
-        doc.select("em,strong,italic,s,i").unwrap()
 
         val filters = dataCenter.ttsPreferences.filterList
 
@@ -417,6 +416,7 @@ object Utils {
                 doc.select(it.lookup).remove()
             }
         }
+        doc.select("em,strong,italic,s,i,a").unwrap()
 
         val textFilters = filters.filter { it.target == TTSFilterTarget.TextChunk }.map { it.compile(doc) }
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/Utils.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/Utils.kt
@@ -405,9 +405,10 @@ object Utils {
             doc.head().children().remove()
 //            doc.head().html("")
         }
-        doc.select("br").forEach {
+        doc.select("br,p,hr").forEach {
             it.after("\n")
         }
+        doc.select("em,strong,italic,s,i").unwrap()
 
         val filters = dataCenter.ttsPreferences.filterList
 

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/Utils.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/Utils.kt
@@ -435,7 +435,7 @@ object Utils {
             // Perform a limited trim operation on excessive spacing, causing "     " to turn into just " " as well as changing \n\n\n\n into \n
             .replace("""([\s ])+""".toRegex(RegexOption.MULTILINE)) { it.groups[0]?.value ?: "" }
             // Shorten long repeating characters such as =====, -----, -=-=-=-=-, ***** or !!!!!!!!
-            .replace("""((?>[◆◇＝_~=*#|+<>\-] ?){4,}|\.{4,}|!{4,}|\?{4,})""".toRegex()) { it.value.replace(" ", "").substring(0, 3) }
+            .replace("""((?>[◆◇＝_~=*#|+<>\-─＊] ?){4,}|\.{4,}|!{4,}|\?{4,})""".toRegex()) { it.value.replace(" ", "").substring(0, 3) }
             .trim()
 
         textFilters.forEach { filter ->


### PR DESCRIPTION
* Adds support for postProxy during document loading: Regular proxy handles url prior redirecting (NU case), meaning it can't really detect what website it would end up on. postProxy is executed on an already loaded response, and allows for fine-tuned proxy-handling in case of JS-loader websites, as after loading initial page we should be able to parse it and acquire actual chapter contents.
* Added inoveltranslations support using postProxy
* Added jetbrains markdown dependency for afformentioned website: They use markdown for internal page formatting (it's quite broken I must add)
* Added ability to designate custom sub-selector method for app-side selectors, allowing for more complex logic than what is possible via pure config (or just a pain to do).
* Added very aggressive stripping of anti-scrapper inserts and shilling for convallariaslibrary.