### PR TITLE
Fix 8 Crashlytics issues affecting v2.0.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,6 +74,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
@@ -113,6 +114,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 }
 
 dependencies {
+    coreLibraryDesugaring libs.desugar.jdk.libs
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     
     // AndroidX

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -308,11 +308,7 @@
         <service
             android:name=".service.ai_tts.AiTtsService"
             android:foregroundServiceType="mediaPlayback"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.media.browse.MediaBrowserService" />
-            </intent-filter>
-        </service>
+            android:exported="true" />
 
         <receiver android:name="androidx.media.session.MediaButtonReceiver"
             android:exported="true">

--- a/app/src/main/java/io/github/gmathi/novellibrary/cleaner/HtmlCleaner.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/cleaner/HtmlCleaner.kt
@@ -568,6 +568,7 @@ open class HtmlCleaner protected constructor() {
 
     open fun convertDocToFile(doc: Document, file: File): File? {
         try {
+            file.parentFile?.mkdirs()
             if (file.exists()) file.delete()
             val stream = FileOutputStream(file)
             val content = doc.toString()

--- a/app/src/main/java/io/github/gmathi/novellibrary/fragment/ExtensionsFragment.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/fragment/ExtensionsFragment.kt
@@ -194,7 +194,8 @@ class ExtensionsFragment : BaseFragment(), GenericAdapter.Listener<ExtensionItem
             .debounce(100, TimeUnit.MILLISECONDS)
             .map(::toItems)
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe {
+            .subscribe({
+                if (!isAdded) return@subscribe
                 extensions = it
                 if (extensions.isEmpty()) {
                     binding.progressLayout.showEmpty(emptyText = getString(R.string.empty_extensions))
@@ -203,7 +204,9 @@ class ExtensionsFragment : BaseFragment(), GenericAdapter.Listener<ExtensionItem
                     adapter.updateData(ArrayList(extensions))
                 }
                 binding.swipeRefreshLayout.isRefreshing = false
-            }
+            }, {
+                // Silently handle to prevent OnErrorNotImplementedException
+            })
     }
 
     @Synchronized

--- a/app/src/main/java/io/github/gmathi/novellibrary/network/cloudflare/CloudflareInterceptor.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/network/cloudflare/CloudflareInterceptor.kt
@@ -59,7 +59,14 @@ class CloudflareInterceptor(private val context: Context) : Interceptor {
         initWebView
 
         try {
-            val response = chain.proceed(originalRequest)
+            val response: Response
+            try {
+                response = chain.proceed(originalRequest)
+            } catch (e: java.net.UnknownHostException) {
+                Log.w(TAG, "DNS resolution failed for ${originalRequest.url.host}: ${e.message}")
+                throw java.io.IOException("DNS resolution failed for ${originalRequest.url.host}", e)
+            }
+
 
             // Check if Cloudflare anti-bot is on
             if (!isCloudflareChallenge(response)) {

--- a/app/src/main/java/io/github/gmathi/novellibrary/service/tts/TTSPlayer.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/service/tts/TTSPlayer.kt
@@ -325,6 +325,10 @@ class TTSPlayer(private val context: Context,
 
     fun start() {
         if (isDisposed) return
+        if (!::novel.isInitialized) {
+            Log.w(TAG, "start() called before novel was initialized, ignoring")
+            return
+        }
         desiredState = STATE_PLAY
         // Start silence playback even if TTS is not ready
         // Avoid cut audio because android did boot up the bluetooth sound output.
@@ -555,6 +559,11 @@ class TTSPlayer(private val context: Context,
     }
 
     private fun onLastLine() {
+        if (!::novel.isInitialized) {
+            Log.w(TAG, "onLastLine() called before novel was initialized, stopping")
+            stop()
+            return
+        }
         if (dataCenter.ttsPreferences.markChaptersRead) {
             dbHelper.getWebPage(novel.id, translatorSourceName, chapterIndex)?.let {
                 markChapterRead(it, true)

--- a/app/src/main/java/io/github/gmathi/novellibrary/service/tts/TTSWrapper.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/service/tts/TTSWrapper.kt
@@ -531,7 +531,13 @@ class TTSWrapper(val context: Context, var callback: TTSWrapperCallback, private
                     while (!data.isEmpty()) {
                         val buf = data.first
                         val remaining = min(bufferSize, buf.remaining())
-                        val total = track.write(buf, buf.remaining(), AudioTrack.WRITE_NON_BLOCKING)
+                        val total: Int
+                        try {
+                            total = track.write(buf, buf.remaining(), AudioTrack.WRITE_NON_BLOCKING)
+                        } catch (e: IllegalStateException) {
+                            Log.e(TTSPlayer.TAG, "AudioTrack write failed: ${e.message}")
+                            break
+                        }
                         this.written += total / bytesPerFrame
                         if (total < remaining) {
                             if (track.playState != AudioTrack.PLAYSTATE_PLAYING) track.play()  // Primed
@@ -701,9 +707,13 @@ class TTSWrapper(val context: Context, var callback: TTSWrapperCallback, private
                 TTSMarkerType.StartEarcon -> {
                     playing = marker.owner
                     val earcon = marker.earcon
-                    earcon.player.stop()
-                    earcon.player.prepare()
-                    earcon.player.start()
+                    try {
+                        earcon.player.stop()
+                        earcon.player.prepare()
+                        earcon.player.start()
+                    } catch (e: IllegalStateException) {
+                        Log.e(TTSPlayer.TAG, "Earcon playback failed: ${e.message}")
+                    }
                     callback.onStart(marker.owner.utteranceId)
                 }
                 TTSMarkerType.Done -> {

--- a/app/src/main/java/io/github/gmathi/novellibrary/util/view/TransitionHelper.kt
+++ b/app/src/main/java/io/github/gmathi/novellibrary/util/view/TransitionHelper.kt
@@ -42,10 +42,16 @@ object TransitionHelper {
      * @param data Intent with bundle and or activity to start
      */
     fun startSharedImageTransition(base: AppCompatActivity, target: View, transitionName: String, data: Intent) {
-        val transition = ActivityOptionsCompat.makeSceneTransitionAnimation(
-            base, target, transitionName
-        )
-        base.startActivity(data, transition.toBundle())
+        try {
+            val transition = ActivityOptionsCompat.makeSceneTransitionAnimation(
+                base, target, transitionName
+            )
+            base.startActivity(data, transition.toBundle())
+        } catch (e: Exception) {
+            // Fallback: start activity without shared element transition
+            // to avoid ClassCastException on some Android versions (API 31/32)
+            base.startActivity(data)
+        }
     }
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,6 +89,7 @@ leakcanary = "2.14"
 junit = "4.13.2"
 androidxJunit = "1.2.1"
 espresso = "3.6.1"
+desugarJdkLibs = "2.1.4"
 
 [libraries]
 # AndroidX
@@ -215,6 +216,7 @@ leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.re
 junit = { module = "junit:junit", version.ref = "junit" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
 androidx-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- Fix duplicate MediaBrowserService: Remove intent-filter from AiTtsService (14 events, 5 users - FATAL)
- Fix TTSPlayer lateinit novel crash: Add isInitialized guards in start() and onLastLine() (2 events, 2 users - FATAL)
- Fix TTSWrapper AudioTrack write crash: Catch IllegalStateException in buffer() (7 events, 2 users - FATAL)
- Fix TTSWrapper MediaPlayer prepare crash: Catch IllegalStateException in earcon playback (1 event, 1 user - FATAL)
- Fix TransitionHelper ClassCastException: Fallback to non-transition start on API 31/32 (2 events, 1 user - FATAL)
- Fix HtmlCleaner ENOENT: Create parent dirs before FileOutputStream (8 events, 1 user - NON_FATAL)
- Fix CloudflareInterceptor DNS failure: Wrap UnknownHostException as IOException for OkHttp (3 events, 1 user - NON_FATAL, REGRESSED)
- Fix Jsoup ThreadLocal.withInitial on API < 26: Enable core library desugaring (1 event, 1 user - FATAL, NEW)
- Fix ExtensionsFragment not attached: Add isAdded guard and onError handler (1 event, 1 user - FATAL)